### PR TITLE
Fix Positional Encoding formulas in documentation

### DIFF
--- a/docs/guides/模块一-前置知识/transformer/3.2 Transformer全貌及代码实现.md
+++ b/docs/guides/模块一-前置知识/transformer/3.2 Transformer全貌及代码实现.md
@@ -663,8 +663,8 @@ class MultiHeadAttention(nn.Module):
 对应第 3.1 节中的 Positional Encoding 设计，实现原论文的正弦/余弦公式：
 
 $$
-\text{PE}(\text{pos}, 2i) = \sin\\left(\frac{\text{pos}}{10000^{2i/d_{model}}}\right), \quad
-\text{PE}(\text{pos}, 2i+1) = \cos\\left(\frac{\text{pos}}{10000^{2i/d_{model}}}\right)
+\text{PE}(\text{pos}, 2i) = \sin\left(\frac{\text{pos}}{10000^{2i/d_{\text{model}}}}\right), \quad
+\text{PE}(\text{pos}, 2i+1) = \cos\left(\frac{\text{pos}}{10000^{2i/d_{\text{model}}}}\right)
 $$
 
 ```python


### PR DESCRIPTION
### change:
Correct the mathematical notation for Positional Encoding in the document.

### before:
```html
<span class="katex-error" title="ParseError: KaTeX parse error: Expected 'EOF', got '\right' at position 79: …{2i/d_{model}}}\̲r̲i̲g̲h̲t̲), \quad
\text{…" style="color:#cc0000">\text{PE}(\text{pos}, 2i) = \sin\\left(\frac{\text{pos}}{10000^{2i/d_{model}}}\right), \quad
\text{PE}(\text{pos}, 2i+1) = \cos\\left(\frac{\text{pos}}{10000^{2i/d_{model}}}\right)</span>
```

<img width="1470" height="609" alt="snipate" src="https://github.com/user-attachments/assets/aa02135d-d872-41bc-b2a9-991165248183" />

### compare
<img width="1211" height="385" alt="kalex" src="https://github.com/user-attachments/assets/3594ea58-6d0f-491f-ac62-006c521c8d24" />

