### PR TITLE
Fix KaTeX formatting in Transformer position encoding guide

### DIFF
--- a/docs/guides/模块一-前置知识/transformer/3.5 Transformer位置编码深入理解.md
+++ b/docs/guides/模块一-前置知识/transformer/3.5 Transformer位置编码深入理解.md
@@ -416,11 +416,11 @@ $$
 在实际工程中，我们不会真的构造一个 $d_k \times d_k$ 的分块对角矩阵再做矩阵乘法。二维旋转可以用逐元素乘法和加法高效实现：
 
 $$
-\tilde{q}\_{2i} = q\_{2i} \cos(m\theta_i) - q\_{2i+1} \sin(m\theta_i)
+\tilde{q}_{2i} = q_{2i} \cos(m\theta_i) - q_{2i+1} \sin(m\theta_i)
 $$
 
 $$
-\tilde{q}\_{2i+1} = q\_{2i} \sin(m\theta_i) + q\_{2i+1} \cos(m\theta_i)
+\tilde{q}_{2i+1} = q_{2i} \sin(m\theta_i) + q_{2i+1} \cos(m\theta_i)
 $$
 
 以下是 RoPE 核心操作的 Python 实现：


### PR DESCRIPTION
# Change
**Current**
<img width="440" height="80" alt="patch1" src="https://github.com/user-attachments/assets/21dd53dc-278c-45f9-937e-41a8575a2b48" />

**Diff**
<img width="450" height="150" alt="diff1" src="https://github.com/user-attachments/assets/91f5be28-6d35-4cf7-a3bd-c29243dcbb83" />
<img width="410" height="150" alt="diff2" src="https://github.com/user-attachments/assets/69c9bc50-d0e7-4330-a95b-4e8104e65c08" />
