### PR TITLE
Fix KaTeX formatting in vector dot product exercise

### DIFF
--- a/docs/guides/模块二-CUDA编程与算子优化/1.4-第一个实用Kernel.md
+++ b/docs/guides/模块二-CUDA编程与算子优化/1.4-第一个实用Kernel.md
@@ -480,7 +480,7 @@ $$
 
 ### 8.1 练习 1：向量点积
 
-实现两个向量的点积 $\text{result} = \sum\_{i=0}^{N-1} A[i] \times B[i]$。
+实现两个向量的点积 $\text{result} = \sum_{i=0}^{N-1} A[i] \times B[i]$。
 
 提示：这需要**规约**（Reduction）——每个线程计算部分乘积，然后在 Block 内用共享内存累加。
 


### PR DESCRIPTION
# Current
<img width="345" height="78" alt="diff2" src="https://github.com/user-attachments/assets/198664ce-379b-49a7-b7f8-a158852dce52" />

# Comparison
<img width="400" height="157" alt="diff1" src="https://github.com/user-attachments/assets/55d0feca-ec93-4d6e-9938-79c56e8dccd5" />
