### PR TITLE
docs: expand programming and math foundations

### DIFF
--- a/docs/guides/模块一-前置知识/第1章-编程语言基础.md
+++ b/docs/guides/模块一-前置知识/第1章-编程语言基础.md
@@ -7,12 +7,1581 @@ order: 1
 tags: ["Python", "C++", "Linux", "开发环境", "前置知识"]
 ---
 
-## 本章简介
+AI Infra 处在算法、框架、编译器、操作系统和硬件的交界处。同一个问题往往要在多种语言和工具之间来回切换：用 Python 描述模型与实验，用 C++ 实现性能敏感路径，用 CUDA 驱动 GPU，再用 Linux 工具定位进程、内存、动态库和网络问题。
 
-本章是 AI Infra 全栈课程的起点，目标是确保你具备后续三个核心模块所需的编程基础能力。
+本章不追求把每门语言的语法完整讲一遍，而是建立一条够用的主线：**能读懂、能修改、能调试，也知道性能成本发生在哪里**。
 
-**Python 进阶**部分涵盖面向对象、装饰器、多进程/多线程编程、性能 profiling 以及 Python 与 C/C++ 的互操作，这些是理解 PyTorch 内部机制和编写高效训练脚本的基础。
+<!-- more -->
 
-**C/C++ 核心**部分聚焦指针与内存管理、编译链接过程、CMake 构建和 C++ 模板基础，目标是能够读懂 CUDA 项目的 host 端代码。
+## 📑 目录
 
-**Linux 与开发环境**部分覆盖 Shell 操作、进程管理、SSH 远程开发、环境隔离（conda/Docker）、GPU 环境配置（CUDA Toolkit/cuDNN）以及 Git 工作流，这是日常 AI Infra 开发的基本功。
+- [1. 学习目标与开发全景](#1-学习目标与开发全景)
+- [2. Python：从脚本到工程](#2-python从脚本到工程)
+- [3. Python 并发与性能分析](#3-python-并发与性能分析)
+- [4. C/C++：内存、生命周期与资源管理](#4-cc内存生命周期与资源管理)
+- [5. C++ 编译、链接、模板与构建系统](#5-c-编译链接模板与构建系统)
+- [6. Python 与 C++ 互操作](#6-python-与-c-互操作)
+- [7. Linux 开发基本功](#7-linux-开发基本功)
+- [8. 环境隔离与 GPU 软件栈](#8-环境隔离与-gpu-软件栈)
+- [9. Git 协作与问题定位方法](#9-git-协作与问题定位方法)
+- [10. 综合实战：给 Python 添加一个 C++ 算子](#10-综合实战给-python-添加一个-c-算子)
+- [总结](#总结)
+- [自我检验清单](#自我检验清单)
+- [练习题](#练习题)
+- [参考资料](#参考资料)
+
+---
+
+## 1. 学习目标与开发全景
+
+完成本章后，你应该能够：
+
+1. 解释 Python 名字、对象、引用、可变性和作用域之间的关系；
+2. 熟练使用迭代器、生成器、装饰器、上下文管理器与类型标注；
+3. 根据任务性质选择线程、进程或异步 I/O，并用工具找到 Python 热点；
+4. 读懂 C/C++ 中的指针、引用、对象生命周期、RAII 和智能指针；
+5. 解释一个 C++ 源文件从预处理到动态装载的全过程；
+6. 看懂常见的模板、STL 容器和 CMake 项目；
+7. 用 `pybind11` 理解 Python 调用 C++ 扩展的基本边界；
+8. 在 Linux 上管理文件、进程、权限、环境变量、动态库和远程任务；
+9. 区分 GPU 驱动、CUDA Toolkit、CUDA Runtime 和框架自带 CUDA 组件；
+10. 用可复现的步骤定位“代码错、环境错还是性能差”。
+
+### 1.1 三层语言各自负责什么
+
+| 层次 | 常用技术 | 优势 | 典型工作 |
+|------|----------|------|----------|
+| 编排层 | Python、Shell | 开发快、生态丰富 | 模型定义、训练脚本、任务编排、数据处理 |
+| 系统层 | C/C++ | 可控的内存与性能、易连接底层 API | 框架核心、算子调度、通信库、Python 扩展 |
+| 设备层 | CUDA C++、Triton | 显式表达 GPU 并行 | Kernel、算子融合、访存优化 |
+
+三层不是互相替代的关系。一个 `torch.matmul(x, w)` 看起来只是一行 Python，实际可能经历：
+
+```text
+Python API
+  └─ 算子分发器（C++）
+      └─ cuBLAS / 自定义 CUDA Kernel
+          └─ GPU 指令与显存访问
+```
+
+因此，AI Infra 工程师最重要的语言能力不是“背语法”，而是**沿调用链跨层追踪问题**。
+
+### 1.2 开始前的最小工具箱
+
+以下命令不要求现在全部掌握，但应该知道它们分别回答什么问题：
+
+```bash
+python --version       # 正在使用哪个 Python
+which python           # 这个可执行文件来自哪里
+python -m pip --version
+
+g++ --version          # C++ 编译器版本
+cmake --version        # 构建系统版本
+
+uname -a               # 内核与系统信息
+ps aux                 # 有哪些进程
+free -h                # 主机内存使用
+df -h                   # 文件系统容量
+
+nvidia-smi             # 驱动可见的 GPU 与进程
+nvcc --version         # CUDA Toolkit 中的编译器版本
+```
+
+> **先建立诊断习惯**：环境问题出现时，先记录命令、输出、工作目录和版本，不要立刻反复重装。可观察的信息越完整，定位越快。
+
+---
+
+## 2. Python：从脚本到工程
+
+### 2.1 名字、对象与引用
+
+Python 变量更准确的说法是“**名字绑定到对象**”。赋值通常不会复制对象，只会建立新的引用：
+
+```python
+a = [1, 2]
+b = a
+b.append(3)
+
+print(a)        # [1, 2, 3]
+print(a is b)   # True：指向同一个对象
+print(a == b)   # True：值相等
+```
+
+需要区分两个运算：
+
+- `is` 比较对象身份，适合写 `x is None`；
+- `==` 调用值比较逻辑，比较“内容是否相等”。
+
+函数参数同样是名字绑定。函数收到的是对象引用，不是“按引用传递”或“按值传递”这两个传统标签中的任意一个：
+
+```python
+def mutate(xs: list[int]) -> None:
+    xs.append(1)          # 修改调用方可见的同一个列表
+
+def rebind(xs: list[int]) -> None:
+    xs = [1]              # 只让局部名字 xs 指向新列表
+
+data: list[int] = []
+mutate(data)
+print(data)               # [1]
+
+rebind(data)
+print(data)               # 仍然是 [1]
+```
+
+这套模型能解释大量常见 Bug：默认可变参数、浅拷贝、缓存污染以及多线程共享状态。
+
+### 2.2 可变对象、不可变对象与拷贝
+
+常见不可变对象包括 `int`、`float`、`bool`、`str`、`bytes` 和元素均不可变时的 `tuple`；常见可变对象包括 `list`、`dict`、`set` 和大多数自定义实例。
+
+#### 默认参数只创建一次
+
+```python
+# 错误：同一个列表会被多次调用共享
+def collect_bad(x: int, result: list[int] = []) -> list[int]:
+    result.append(x)
+    return result
+
+# 正确：用 None 表示“未提供”
+def collect(x: int, result: list[int] | None = None) -> list[int]:
+    if result is None:
+        result = []
+    result.append(x)
+    return result
+```
+
+默认参数在函数定义时求值，而不是每次调用时求值。
+
+#### 浅拷贝与深拷贝
+
+```python
+import copy
+
+src = [[1], [2]]
+shallow = src.copy()           # 只复制最外层列表
+deep = copy.deepcopy(src)      # 递归复制内部对象
+
+shallow[0].append(9)
+print(src)                     # [[1, 9], [2]]
+print(deep)                    # [[1], [2]]
+```
+
+深拷贝并非默认答案。对大型张量或模型状态做无意复制可能产生巨大的内存和时间开销。更好的做法是先明确：哪些数据需要独占，哪些可以只读共享。
+
+### 2.3 作用域、闭包与 LEGB
+
+Python 按 **LEGB** 顺序查找名字：Local（局部）→ Enclosing（外层函数）→ Global（模块）→ Builtins（内置）。
+
+闭包会保存外层作用域中的变量：
+
+```python
+from collections.abc import Callable
+
+def make_multiplier(scale: float) -> Callable[[float], float]:
+    def multiply(x: float) -> float:
+        return x * scale
+    return multiply
+
+double = make_multiplier(2.0)
+print(double(3.0))  # 6.0
+```
+
+循环中创建闭包时要注意**延迟绑定**：闭包在调用时才读取外层名字。
+
+```python
+# 三个函数最终都读取同一个 i，结果都是 2
+bad = [lambda: i for i in range(3)]
+
+# 用默认参数在每轮定义时保存当前值
+good = [lambda i=i: i for i in range(3)]
+print([fn() for fn in good])  # [0, 1, 2]
+```
+
+如果需要在内层函数中重新绑定外层函数的名字，使用 `nonlocal`；重新绑定模块全局名字则使用 `global`。优先通过参数和返回值传递状态，通常更易测试。
+
+### 2.4 类、数据模型与协议
+
+Python 的特殊方法让对象接入语言协议。例如，实现 `__len__` 后可调用 `len(obj)`，实现 `__iter__` 后可被 `for` 遍历。
+
+```python
+from dataclasses import dataclass
+from collections.abc import Iterator
+
+@dataclass
+class Batch:
+    samples: list[list[float]]
+
+    def __len__(self) -> int:
+        return len(self.samples)
+
+    def __iter__(self) -> Iterator[list[float]]:
+        return iter(self.samples)
+
+batch = Batch([[1.0, 2.0], [3.0, 4.0]])
+print(len(batch))
+for sample in batch:
+    print(sample)
+```
+
+常见特殊方法及用途：
+
+| 方法 | 触发方式 | 典型用途 |
+|------|----------|----------|
+| `__init__` | 创建实例后 | 初始化实例状态 |
+| `__repr__` | `repr(obj)`、调试器 | 无歧义的调试表示 |
+| `__call__` | `obj(...)` | 让实例表现得像函数 |
+| `__enter__` / `__exit__` | `with` | 管理资源生命周期 |
+| `__iter__` / `__next__` | `for`、`next` | 定义迭代协议 |
+| `__getitem__` | `obj[key]` | 索引、切片或映射访问 |
+
+#### 实例方法、类方法和静态方法
+
+- 实例方法的第一个参数是 `self`，操作具体对象；
+- `@classmethod` 的第一个参数是 `cls`，常用于备选构造器；
+- `@staticmethod` 不接收隐式对象，仅用于把相关工具函数组织在类命名空间中。
+
+```python
+@dataclass
+class Device:
+    kind: str
+    index: int
+
+    @classmethod
+    def parse(cls, value: str) -> "Device":
+        kind, index = value.split(":")
+        return cls(kind=kind, index=int(index))
+
+device = Device.parse("cuda:0")
+```
+
+### 2.5 迭代器与生成器：按需生产数据
+
+**可迭代对象**能返回迭代器；**迭代器**保存遍历状态，并通过 `__next__` 逐个返回元素。生成器函数是编写迭代器的简洁方式：
+
+```python
+from collections.abc import Iterator
+
+def read_batches(path: str, batch_size: int) -> Iterator[list[str]]:
+    batch: list[str] = []
+    with open(path, encoding="utf-8") as file:
+        for line in file:
+            batch.append(line.rstrip("\n"))
+            if len(batch) == batch_size:
+                yield batch
+                batch = []
+    if batch:
+        yield batch
+```
+
+`yield` 返回一个值后暂停函数，下一次迭代从暂停位置继续。与一次性构造完整列表相比，生成器的峰值内存通常只与一个批次相关，适合流式数据管线。
+
+需要记住：
+
+- 生成器通常只能消费一次；
+- 惰性求值会把异常推迟到迭代时；
+- 把生成器转成 `list` 会重新物化所有元素，失去节省内存的优势。
+
+### 2.6 装饰器：在调用边界附加行为
+
+装饰器接收一个可调用对象，并返回另一个可调用对象。下面的计时器保留了原函数的元信息：
+
+```python
+from collections.abc import Callable
+from functools import wraps
+from time import perf_counter
+from typing import ParamSpec, TypeVar
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+def timed(fn: Callable[P, R]) -> Callable[P, R]:
+    @wraps(fn)
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+        start = perf_counter()
+        try:
+            return fn(*args, **kwargs)
+        finally:
+            elapsed_ms = (perf_counter() - start) * 1_000
+            print(f"{fn.__name__}: {elapsed_ms:.3f} ms")
+    return wrapper
+
+@timed
+def preprocess(values: list[float]) -> list[float]:
+    return [value * 2 for value in values]
+```
+
+`@timed` 等价于 `preprocess = timed(preprocess)`。`functools.wraps` 会保留函数名、文档字符串等属性，这对日志、测试和框架反射很重要。
+
+装饰器适合日志、缓存、权限检查和性能观测；如果只是单个调用点需要计时，一个普通的 `with timer():` 往往更直白，不必为了“高级”而使用装饰器。
+
+### 2.7 上下文管理器：让资源必定释放
+
+`with` 把资源的获取和释放放在同一个词法范围内，即使发生异常，也会执行清理逻辑：
+
+```python
+from contextlib import contextmanager
+from collections.abc import Iterator
+from time import perf_counter
+
+@contextmanager
+def timer(name: str) -> Iterator[None]:
+    start = perf_counter()
+    try:
+        yield
+    finally:
+        elapsed_ms = (perf_counter() - start) * 1_000
+        print(f"{name}: {elapsed_ms:.3f} ms")
+
+with timer("load data"):
+    data = [value for value in range(100_000)]
+```
+
+文件、锁、数据库连接、临时目录、自动混合精度上下文都适合这种模式。它和 C++ 的 RAII 解决的是同一个问题：**资源生命周期必须有清晰边界**。
+
+### 2.8 异常处理：只捕获能够处理的错误
+
+```python
+def parse_world_size(raw: str) -> int:
+    try:
+        world_size = int(raw)
+    except ValueError as exc:
+        raise ValueError(f"WORLD_SIZE 必须是整数，实际为 {raw!r}") from exc
+
+    if world_size <= 0:
+        raise ValueError("WORLD_SIZE 必须大于 0")
+    return world_size
+```
+
+建议遵循三条原则：
+
+1. 捕获具体异常，不要用空的 `except:` 吞掉 `KeyboardInterrupt` 等信号；
+2. 只有在能恢复、补充上下文或转换抽象层时才捕获；
+3. 用 `raise ... from exc` 保留根因链。
+
+不要把异常用于正常的高频控制流，尤其是在性能敏感循环中。
+
+### 2.9 类型标注与数据类
+
+类型标注主要服务于静态检查、IDE 和读者，不会自动在运行时验证类型：
+
+```python
+from dataclasses import dataclass
+from collections.abc import Sequence
+
+@dataclass(frozen=True)
+class ShardSpec:
+    rank: int
+    world_size: int
+
+def shard(values: Sequence[int], spec: ShardSpec) -> Sequence[int]:
+    return values[spec.rank::spec.world_size]
+```
+
+常用选择：
+
+- 参数只要求“可迭代”或“序列”能力时，标注 `Iterable[T]`、`Sequence[T]` 等抽象协议；
+- 返回具体容器时可标注 `list[T]`、`dict[K, V]`；
+- `T | None` 表示值可能缺失；
+- `Protocol` 可描述结构化接口，减少不必要的继承；
+- `dataclass` 适合主要承载数据、规则简单的对象。
+
+类型系统的目标是尽早暴露接口误用，不是把动态语言硬写成 Java。公共边界优先标清，局部显而易见的变量不必逐个标注。
+
+---
+
+## 3. Python 并发与性能分析
+
+### 3.1 先分清并发与并行
+
+- **并发（concurrency）**：多个任务在同一时间段内推进；
+- **并行（parallelism）**：多个任务在同一时刻真正执行。
+
+选择并发模型前，先判断瓶颈：
+
+| 任务类型 | 典型例子 | 常见选择 |
+|----------|----------|----------|
+| I/O 密集 | 请求服务、读取大量小文件 | 线程或 `asyncio` |
+| Python CPU 密集 | 纯 Python 解析、复杂循环 | 多进程或原生扩展 |
+| 原生算子密集 | NumPy/PyTorch/CUDA 运算 | 由底层线程池/GPU 并行，Python 负责调度 |
+| 大数据跨进程 | 数据加载、共享缓存 | 多进程 + 共享内存，谨慎序列化 |
+
+### 3.2 GIL 到底限制了什么
+
+常见 CPython 构建使用全局解释器锁（GIL）保护解释器内部状态。同一进程中，通常只有一个线程能同时执行 Python 字节码。因此，两个执行纯 Python CPU 循环的线程一般不能获得两倍速度。
+
+但这不等于“Python 线程没有用”：
+
+- 阻塞 I/O 时解释器会释放 GIL；
+- NumPy、PyTorch 等原生扩展可在耗时计算时释放 GIL；
+- 后台日志、预取和轻量控制任务常适合线程。
+
+GIL 是 CPython 实现细节，不应泛化成所有 Python 实现或所有构建的永恒规则。判断性能时要测量当前解释器和依赖，而不是只背结论。
+
+### 3.3 线程：共享内存，也共享风险
+
+```python
+from concurrent.futures import ThreadPoolExecutor
+from urllib.request import urlopen
+
+def fetch_size(url: str) -> int:
+    with urlopen(url, timeout=10) as response:
+        return len(response.read())
+
+urls = ["https://example.com"] * 4
+with ThreadPoolExecutor(max_workers=4) as pool:
+    sizes = list(pool.map(fetch_size, urls))
+```
+
+线程共享进程内存，传数据便宜，但对同一可变对象的“读取—修改—写回”可能产生竞态。需要锁时让临界区尽可能小：
+
+```python
+from threading import Lock
+
+lock = Lock()
+counter = 0
+
+def increment() -> None:
+    global counter
+    with lock:
+        counter += 1
+```
+
+不要依赖“某个内置操作看起来是原子的”来设计正确性；解释器版本、对象实现或复合操作都可能破坏这种假设。
+
+### 3.4 多进程：绕开 GIL，但数据搬运有成本
+
+```python
+from concurrent.futures import ProcessPoolExecutor
+
+def count_primes(limit: int) -> int:
+    def is_prime(value: int) -> bool:
+        if value < 2:
+            return False
+        return all(value % divisor for divisor in range(2, int(value**0.5) + 1))
+    return sum(is_prime(value) for value in range(limit))
+
+if __name__ == "__main__":
+    with ProcessPoolExecutor() as pool:
+        results = list(pool.map(count_primes, [50_000] * 4))
+```
+
+`if __name__ == "__main__":` 对使用 `spawn` 启动子进程的平台尤其重要，可避免子进程重新导入模块时递归创建新进程。
+
+多进程的主要成本包括：
+
+- 创建进程和独立解释器；
+- 参数与返回值的序列化/反序列化；
+- 复制或映射内存；
+- 进程间通信与同步。
+
+如果每个任务只做几十微秒工作，调度成本可能比计算更高。应增大任务粒度，并尽量避免来回传递大型数组或张量。
+
+> **GPU 关联**：CUDA 上下文和多进程启动方式组合不当会引发初始化错误或额外显存占用。使用框架的数据加载与分布式能力时，应遵循框架推荐的启动器和 start method，不要在父进程初始化 CUDA 后随意 `fork`。
+
+### 3.5 `asyncio`：协作式 I/O 并发
+
+`asyncio` 用事件循环调度协程。协程只会在 `await` 处主动让出控制权：
+
+```python
+import asyncio
+
+async def worker(name: str, delay: float) -> str:
+    await asyncio.sleep(delay)  # 模拟非阻塞 I/O
+    return name
+
+async def main() -> None:
+    results = await asyncio.gather(
+        worker("a", 0.2),
+        worker("b", 0.1),
+    )
+    print(results)
+
+asyncio.run(main())
+```
+
+在事件循环中直接执行阻塞 I/O 或长时间 CPU 计算会卡住所有协程。此时应改用异步库，或把阻塞工作放到线程/进程执行器。
+
+### 3.6 正确做基准测试
+
+性能测试最常见的错误是只测一次、把初始化算进去，或者忘记 GPU 异步执行。
+
+纯 CPU 小片段可用 `timeit`：
+
+```bash
+python -m timeit -s 'xs = list(range(1000))' 'sum(xs)'
+```
+
+手工测试至少要做到：
+
+```python
+from statistics import median
+from time import perf_counter
+
+def benchmark(fn, warmup: int = 5, repeat: int = 20) -> float:
+    for _ in range(warmup):
+        fn()
+
+    samples = []
+    for _ in range(repeat):
+        start = perf_counter()
+        fn()
+        samples.append(perf_counter() - start)
+    return median(samples)
+```
+
+对于 GPU，Kernel 启动通常是异步的。CPU 计时器只量到“提交任务”的时间，需要在边界同步，或使用框架提供的 GPU Event。同步会改变流水线行为，因此端到端吞吐和单算子延迟应分别测量。
+
+### 3.7 从“慢”定位到具体代码
+
+建议按由粗到细的顺序：
+
+1. **端到端计时**：确认回归真实存在；
+2. **阶段计时**：区分数据、计算、通信和保存；
+3. **函数级 profiling**：用 `cProfile` 找累计耗时高的函数；
+4. **行级/采样 profiling**：进一步定位热点行或原生调用栈；
+5. **内存 profiling**：用 `tracemalloc` 等工具找 Python 分配增长；
+6. **GPU profiling**：进入 PyTorch Profiler、Nsight Systems/Compute 等专用工具。
+
+```bash
+python -m cProfile -o profile.out train.py
+python -m pstats profile.out
+```
+
+在 `pstats` 中可按累计时间排序：
+
+```text
+sort cumulative
+stats 30
+```
+
+检查 Python 内存分配：
+
+```python
+import tracemalloc
+
+tracemalloc.start()
+# 运行待检查代码
+snapshot = tracemalloc.take_snapshot()
+for stat in snapshot.statistics("lineno")[:10]:
+    print(stat)
+```
+
+### 3.8 Python 性能优化的优先级
+
+推荐顺序如下：
+
+1. 先改算法复杂度和数据结构；
+2. 减少不必要的 I/O、复制和序列化；
+3. 把细粒度 Python 循环改成批处理/向量化原生算子；
+4. 减少 Python 与 C++/GPU 边界的频繁往返；
+5. 确认热点后，再写 C++、CUDA 或 Triton 扩展。
+
+例如，一百万次小算子调用即使每次都很快，也会累积大量调度开销。把数据组成批次后调用一次大算子，通常比微调 Python 语法有效得多。
+
+---
+
+## 4. C/C++：内存、生命周期与资源管理
+
+### 4.1 值、地址、指针与引用
+
+```cpp
+#include <iostream>
+
+int main() {
+    int value = 42;
+    int* ptr = &value;  // ptr 保存 value 的地址
+    int& ref = value;   // ref 是 value 的别名
+
+    *ptr = 7;           // 解引用指针并写入
+    ref += 1;
+
+    std::cout << value << '\n';  // 8
+}
+```
+
+可以先用这张表建立直觉：
+
+| 概念 | 能否为空 | 能否改指向 | 常见用途 |
+|------|----------|------------|----------|
+| 值 `T` | 否 | 不适用 | 拥有一个独立对象 |
+| 指针 `T*` | 可以是 `nullptr` | 可以 | 可选对象、数组、底层接口、非拥有观察 |
+| 引用 `T&` | 语言语义上必须绑定对象 | 不可以重新绑定 | 必须存在的别名、函数参数 |
+| 常量引用 `const T&` | 必须绑定对象 | 不可以 | 避免复制且不允许修改 |
+
+函数参数表达的接口意图应尽可能清晰：
+
+```cpp
+void consume(T value);          // 按值：函数获得自己的对象
+void update(T& value);          // 可变借用：函数会修改调用方对象
+void inspect(const T& value);   // 只读借用：避免复制
+void optional(T* value);        // 指针可能为空，通常不拥有对象
+```
+
+对小型标量（`int`、`float`、指针）按值传递通常最清楚；不要机械地把所有参数都改成引用。
+
+### 4.2 数组、指针与连续内存
+
+原生数组在大多数表达式中会退化为首元素指针，因此单独的 `T*` 不携带长度：
+
+```cpp
+void scale(float* data, std::size_t size, float factor) {
+    for (std::size_t i = 0; i < size; ++i) {
+        data[i] *= factor;
+    }
+}
+```
+
+现代 C++ 中优先用能表达长度的类型：
+
+```cpp
+#include <span>
+
+void scale(std::span<float> values, float factor) {
+    for (float& value : values) {
+        value *= factor;
+    }
+}
+```
+
+`std::span` 不拥有数据，只是“指针 + 长度”的轻量视图。调用期间底层内存必须仍然有效。
+
+二维矩阵通常线性存放。行主序矩阵 `A[M][N]` 的 `(row, col)` 对应偏移：
+
+$$
+\text{offset} = row \times N + col
+$$
+
+这个公式会在 CUDA 中反复出现。访问顺序是否连续，直接影响 CPU cache 和 GPU 合并访存效率。
+
+### 4.3 对象存储期与生命周期
+
+常见存储位置的说法是“栈”和“堆”，但更准确地应关注**对象的存储期和所有权**：
+
+```cpp
+void example() {
+    int local = 1;                  // 自动存储期，离开作用域销毁
+    auto buffer = new float[1024];  // 动态分配，必须显式 delete[]
+    delete[] buffer;
+}
+```
+
+手工 `new`/`delete` 容易产生：
+
+- 内存泄漏：忘记释放；
+- 重复释放：同一地址释放两次；
+- 悬空指针：对象已销毁，指针仍被使用；
+- 分配/释放形式不匹配：`new[]` 配了 `delete`；
+- 异常路径泄漏：释放前函数提前退出。
+
+因此现代 C++ 的默认原则是：**让资源由对象管理，让对象由作用域管理。**
+
+### 4.4 RAII：把资源绑定到对象生命周期
+
+RAII（Resource Acquisition Is Initialization）在构造时获取资源，在析构时释放资源：
+
+```cpp
+#include <cstdio>
+#include <stdexcept>
+
+class File {
+public:
+    explicit File(const char* path)
+        : handle_(std::fopen(path, "rb")) {
+        if (handle_ == nullptr) {
+            throw std::runtime_error("failed to open file");
+        }
+    }
+
+    ~File() {
+        std::fclose(handle_);
+    }
+
+    File(const File&) = delete;
+    File& operator=(const File&) = delete;
+
+private:
+    std::FILE* handle_;
+};
+```
+
+无论函数正常返回还是抛出异常，局部对象的析构函数都会执行。文件、锁、主机内存、GPU 内存、CUDA Stream 都可以用同一思想管理。
+
+实际项目中优先使用标准库已有的 RAII 类型，如 `std::vector`、`std::string`、`std::fstream`、`std::lock_guard` 和智能指针，不要重复造轮子。
+
+### 4.5 智能指针与所有权
+
+```cpp
+#include <memory>
+
+auto unique = std::make_unique<Buffer>(1024);  // 唯一所有权
+auto shared = std::make_shared<Buffer>(1024);  // 共享所有权
+```
+
+| 类型 | 语义 | 成本与注意点 |
+|------|------|--------------|
+| `std::unique_ptr<T>` | 唯一拥有，可移动不可复制 | 成本接近裸指针，默认首选 |
+| `std::shared_ptr<T>` | 引用计数共享拥有 | 有计数与控制块成本，循环引用需 `weak_ptr` |
+| `std::weak_ptr<T>` | 不增加引用计数的观察者 | 使用前要 `lock()` 检查对象是否仍存在 |
+| `T*` / `T&` | 通常表示非拥有访问 | 被指向对象必须活得足够久 |
+
+如果所有权没有共享需求，不要使用 `shared_ptr`。“避免思考所有权”不是共享所有权的合理理由。
+
+### 4.6 拷贝、移动与 Rule of Zero
+
+`std::vector` 等容器拥有资源，复制会复制内容，移动则转移内部资源：
+
+```cpp
+#include <utility>
+#include <vector>
+
+std::vector<float> make_buffer() {
+    std::vector<float> values(1'000'000, 0.0f);
+    return values;  // 编译器通常消除复制，必要时可移动
+}
+
+auto a = make_buffer();
+auto b = std::move(a);  // a 仍有效，但内容处于未指定状态
+```
+
+如果类只由标准库 RAII 成员组成，通常无需手写析构、复制和移动操作，这就是 **Rule of Zero**。只有直接管理特殊资源时才需要自定义这些操作，并清晰定义所有权。
+
+不要随手对返回值写 `std::move`；它可能阻止返回值优化。也不要在移动后假设源对象仍保留原内容。
+
+### 4.7 `const`：把不可修改写进接口
+
+```cpp
+const float* p1;        // 指向 const float：不能通过 p1 改值
+float* const p2 = ptr;  // const 指针：不能让 p2 改指向
+const float* const p3 = ptr;
+```
+
+成员函数末尾的 `const` 表示不修改对象的可观察状态：
+
+```cpp
+class TensorView {
+public:
+    std::size_t size() const { return size_; }
+private:
+    std::size_t size_{};
+};
+```
+
+`const` 有助于编译器和读者验证接口，但不能自动解决并发安全与底层别名问题。
+
+### 4.8 未定义行为为什么危险
+
+越界访问、使用悬空引用、有符号整数溢出、数据竞争等可能触发未定义行为（Undefined Behavior，UB）。编译器可以假设 UB 永不发生，并据此优化；程序结果不一定只是“报错”，也可能在调试版正常、优化版悄悄算错。
+
+```cpp
+std::vector<int> values(4);
+values[4] = 1;  // 越界，未定义行为
+```
+
+调试时可启用警告和 Sanitizer：
+
+```bash
+g++ -std=c++20 -Wall -Wextra -Wpedantic \
+    -fsanitize=address,undefined -g main.cpp -o app
+./app
+```
+
+AddressSanitizer 常用于发现越界、use-after-free；UndefinedBehaviorSanitizer 检查多类 UB；ThreadSanitizer 可定位数据竞争，但通常不能和 AddressSanitizer 同时启用。
+
+---
+
+## 5. C++ 编译、链接、模板与构建系统
+
+### 5.1 从源代码到可执行文件
+
+```text
+源文件 .cpp
+  └─ 预处理：展开 #include、宏和条件编译
+      └─ 编译：语法/类型检查并生成汇编
+          └─ 汇编：生成目标文件 .o
+              └─ 链接：解析符号并生成可执行文件或库
+```
+
+可以逐步观察：
+
+```bash
+g++ -E main.cpp -o main.ii       # 只预处理
+g++ -S main.ii -o main.s         # 生成汇编
+g++ -c main.cpp -o main.o        # 生成目标文件
+g++ main.o -o app                # 链接
+```
+
+头文件通常放声明，源文件放定义：
+
+```cpp
+// add.h
+#pragma once
+int add(int lhs, int rhs);
+```
+
+```cpp
+// add.cpp
+#include "add.h"
+int add(int lhs, int rhs) {
+    return lhs + rhs;
+}
+```
+
+### 5.2 编译错误、链接错误与运行时装载错误
+
+三类错误不要混在一起：
+
+| 阶段 | 典型报错 | 常见原因 |
+|------|----------|----------|
+| 编译 | `not declared`、类型不匹配 | 缺声明、模板实例化失败、语法错误 |
+| 链接 | `undefined reference` | 只声明未定义、漏链接库、ABI/签名不一致 |
+| 运行时装载 | `cannot open shared object file` | 动态库不在搜索路径、架构不匹配 |
+
+定位符号和依赖的常用命令：
+
+```bash
+nm -C build/app | less          # 查看并反修饰 C++ 符号
+ldd build/app                   # Linux：查看动态库依赖
+readelf -d build/app            # 查看 ELF 动态段
+```
+
+在 macOS 上，对应工具通常是 `otool -L`。
+
+### 5.3 静态库与动态库
+
+- 静态库（Linux 常见 `.a`）在链接时把所需代码并入目标文件；部署直接，但产物可能更大；
+- 动态库（Linux `.so`、macOS `.dylib`）在装载/运行时解析；可被多个程序共享，但要处理搜索路径与 ABI 兼容。
+
+Linux 动态库搜索会受到二进制的 RPATH/RUNPATH、`LD_LIBRARY_PATH`、系统缓存与默认目录影响。临时设置 `LD_LIBRARY_PATH` 适合诊断，不应成为掩盖安装布局问题的长期万能方案。
+
+### 5.4 ABI：源码兼容不代表二进制兼容
+
+ABI（Application Binary Interface）规定二进制层面的调用约定、名称修饰、对象布局和标准库类型实现等。以下情况都可能造成 ABI 不兼容：
+
+- 编译器或标准库不一致；
+- 编译选项改变对象布局或 C++ ABI；
+- 库升级后导出符号发生变化；
+- Debug/Release 运行库混用；
+- CPU 架构不同。
+
+Python C++ 扩展“能编译但导入失败”时，除了 Python 路径，还要检查扩展和依赖库的 ABI、架构与符号。
+
+### 5.5 模板：在编译期生成类型特化代码
+
+```cpp
+template <typename T>
+T add(T lhs, T rhs) {
+    return lhs + rhs;
+}
+
+auto i = add(1, 2);        // 实例化 add<int>
+auto f = add(1.0f, 2.0f);  // 实例化 add<float>
+```
+
+模板定义通常要放在头文件中，因为编译器在使用点需要看到完整定义才能实例化。CUDA 和高性能计算代码大量使用模板来表达：
+
+- 数据类型：`float`、`half`、`bfloat16`；
+- tile 大小和线程块配置；
+- 布局与转置选项；
+- 编译期分支和特化实现。
+
+非类型模板参数可以把尺寸变成编译期常量：
+
+```cpp
+template <typename T, std::size_t N>
+T sum(const std::array<T, N>& values) {
+    T result{};
+    for (const T& value : values) {
+        result += value;
+    }
+    return result;
+}
+```
+
+模板错误往往很长。定位时从最前面的“用户代码实例化位置”和最底层的真正约束失败开始看，不要被中间几十层展开吓住。
+
+### 5.6 STL 容器与迭代器
+
+| 类型 | 内存/访问特征 | 常见用途 |
+|------|---------------|----------|
+| `std::vector<T>` | 连续内存，随机访问 O(1) | 数值缓冲区，默认序列容器 |
+| `std::array<T, N>` | 固定大小、连续内存 | 编译期已知的小数组 |
+| `std::deque<T>` | 分段存储，两端插入高效 | 队列、滑动窗口 |
+| `std::unordered_map<K,V>` | 哈希表，平均 O(1) 查找 | 无序键值索引 |
+| `std::map<K,V>` | 有序树，O(log n) | 需要有序遍历/范围查询 |
+
+`std::vector` 扩容可能重新分配内存，使原有指针、引用和迭代器失效：
+
+```cpp
+std::vector<int> values;
+values.reserve(1024);  // 已知规模时可减少重复扩容
+```
+
+性能敏感代码除了看大 O 复杂度，还要看连续性、分配次数、缓存局部性和元素大小。很多场景中，线性扫描连续 `vector` 比理论查找复杂度更低但指针跳转频繁的结构更快。
+
+### 5.7 最小 CMake 项目
+
+目录：
+
+```text
+vector_ops/
+├── CMakeLists.txt
+├── include/vector_ops.h
+└── src/vector_ops.cpp
+```
+
+`CMakeLists.txt`：
+
+```cmake
+cmake_minimum_required(VERSION 3.20)
+project(vector_ops LANGUAGES CXX)
+
+add_library(vector_ops src/vector_ops.cpp)
+target_include_directories(vector_ops PUBLIC include)
+target_compile_features(vector_ops PUBLIC cxx_std_20)
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+  target_compile_options(vector_ops PRIVATE -Wall -Wextra -Wpedantic)
+endif()
+```
+
+构建：
+
+```bash
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build --parallel
+```
+
+现代 CMake 的核心是 **target**。用 `target_include_directories`、`target_link_libraries`、`target_compile_features` 描述依赖，少用全局的 `include_directories` 和手工拼接编译命令。
+
+### 5.8 C++ 并发的最小认知
+
+多个线程并发访问同一内存，其中至少一个写入且缺乏同步，就可能形成数据竞争，属于未定义行为。
+
+```cpp
+#include <mutex>
+
+std::mutex mutex;
+int counter = 0;
+
+void increment() {
+    std::lock_guard<std::mutex> guard(mutex);
+    ++counter;
+}
+```
+
+互斥锁保证临界区互斥，原子类型适合简单共享状态，条件变量用于等待状态变化。不要把 `volatile` 当作线程同步工具；它不提供原子性或线程间 happens-before 关系。
+
+高性能并发优化前，首先保证正确性，并使用 ThreadSanitizer 等工具检查数据竞争。
+
+---
+
+## 6. Python 与 C++ 互操作
+
+### 6.1 为什么需要跨语言边界
+
+常见目的包括：
+
+- 复用已有 C/C++ 库；
+- 把 Python 热点循环下沉到原生代码；
+- 接入驱动、通信库或自定义硬件接口；
+- 为 PyTorch 等框架添加自定义算子。
+
+跨语言并不自动变快。一次调用要做参数检查、类型/布局转换、可能的数据复制和异常翻译。如果每个元素都跨一次边界，绑定开销可能完全吞掉原生计算收益。理想接口通常传递一个批次或连续缓冲区。
+
+### 6.2 `ctypes`：调用稳定的 C ABI
+
+C++ 先导出一个 C 接口：
+
+```cpp
+// scale.cpp
+extern "C" void scale(float* data, int size, float factor) {
+    for (int i = 0; i < size; ++i) {
+        data[i] *= factor;
+    }
+}
+```
+
+编译动态库：
+
+```bash
+g++ -O3 -shared -fPIC scale.cpp -o libscale.so
+```
+
+Python 侧调用：
+
+```python
+import ctypes
+from array import array
+
+library = ctypes.CDLL("./libscale.so")
+library.scale.argtypes = [
+    ctypes.POINTER(ctypes.c_float),
+    ctypes.c_int,
+    ctypes.c_float,
+]
+library.scale.restype = None
+
+values = array("f", [1.0, 2.0, 3.0])
+pointer = (ctypes.c_float * len(values)).from_buffer(values)
+library.scale(pointer, len(values), 2.0)
+print(values)
+```
+
+`ctypes` 简单直接，但类型、长度和生命周期主要靠调用者保证。签名写错可能导致崩溃，而不只是普通 Python 异常。
+
+### 6.3 `pybind11`：自然地绑定 C++ 接口
+
+`pybind11` 能把 C++ 函数、类和异常映射成 Python 对象：
+
+```cpp
+#include <pybind11/pybind11.h>
+
+int add(int lhs, int rhs) {
+    return lhs + rhs;
+}
+
+PYBIND11_MODULE(vector_ops, module) {
+    module.doc() = "minimal vector ops extension";
+    module.def("add", &add, pybind11::arg("lhs"), pybind11::arg("rhs"));
+}
+```
+
+绑定大型数组时要特别核对：
+
+- dtype 是否匹配；
+- shape 和 stride 是否符合算法假设；
+- 数据是否连续；
+- 内存位于 CPU 还是 GPU；
+- 谁拥有底层存储，返回后是否仍有效；
+- 计算期间是否应该释放 GIL；
+- 原生异常如何转换为 Python 异常。
+
+### 6.4 零拷贝不是“没有条件”
+
+所谓零拷贝通常只是共享同一块底层内存。它要求双方对以下契约达成一致：
+
+```text
+地址 + 元素类型 + 形状 + 步长 + 设备 + 生命周期 + 可变性
+```
+
+任何一项不匹配都可能导致隐式复制、错误结果或越界访问。比如转置后的 NumPy 数组可能不是 C 连续布局；只拿首地址并按连续数组读取会得到错误数据。
+
+> **核心原则**：把数据布局和所有权当作接口的一部分，而不是实现细节。
+
+---
+
+## 7. Linux 开发基本功
+
+### 7.1 文件、目录与文本流
+
+```bash
+pwd                         # 当前目录
+ls -lah                     # 包括隐藏文件的详细列表
+mkdir -p runs/exp01/logs     # 递归创建目录
+cp -a configs runs/exp01/   # 保留属性地复制
+mv old_name new_name
+rm -i file                  # 交互式删除；危险命令先确认路径
+
+find runs -type f -name '*.log'
+rg 'CUDA error|out of memory' runs
+```
+
+Shell 的组合能力来自标准输入、标准输出和标准错误：
+
+```bash
+python train.py >train.log 2>train.err       # 分别重定向
+python train.py >train.all.log 2>&1           # 合并输出
+rg 'loss=' train.log | tail -n 20
+```
+
+管道把左侧标准输出连接到右侧标准输入。每一段都应完成一个清晰任务，复杂且需要维护的流程应写成脚本并纳入版本控制。
+
+### 7.2 引号、变量与退出码
+
+```bash
+name='experiment 01'
+printf '%s\n' "$name"   # 双引号保留为一个参数
+printf '%s\n' '$name'   # 单引号不展开变量
+```
+
+未加引号的变量可能发生单词分割和通配符展开。Shell 脚本中几乎总应写 `"$variable"`。
+
+每个命令都有退出码：`0` 表示成功，非零表示失败。
+
+```bash
+python check_data.py
+status=$?
+printf 'exit code: %s\n' "$status"
+```
+
+健壮的 Bash 脚本常以此开头：
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+```
+
+- `-e`：未处理的失败使脚本退出；
+- `-u`：使用未定义变量时报错；
+- `pipefail`：管道中任一命令失败，整个管道失败。
+
+这些选项并不能替代清晰的错误处理，尤其要理解条件语句和管道中的例外语义。
+
+### 7.3 权限模型
+
+```bash
+ls -l script.sh
+# -rwxr-x---  owner group ... script.sh
+
+chmod u+x script.sh          # 给所有者增加执行权限
+chmod 640 config.yaml        # owner: rw, group: r, other: none
+```
+
+`r/w/x` 对文件分别表示读、写、执行；对目录则表示列出名称、修改目录项、穿越目录。权限问题先用 `ls -l`、`id` 和父目录权限定位，不要习惯性 `chmod 777`。
+
+### 7.4 进程、作业与信号
+
+```bash
+ps -ef | rg train.py
+pgrep -af train.py
+top                         # 或 htop
+
+python train.py &           # 后台运行
+jobs
+fg %1                       # 拉回前台
+```
+
+发送信号：
+
+```bash
+kill -TERM <pid>            # 请求进程优雅退出
+kill -INT <pid>             # 类似 Ctrl-C
+kill -KILL <pid>            # 内核立即终止，无法清理；最后手段
+```
+
+优先使用 `SIGTERM`，让程序有机会保存 checkpoint、释放共享资源和刷新日志。`SIGKILL` 无法被捕获或清理。
+
+长期远程任务可使用 `tmux` 或集群调度系统，而不是仅依赖 SSH 终端：
+
+```bash
+tmux new -s train
+# Ctrl-b d：退出但保持会话
+tmux attach -t train
+```
+
+### 7.5 查看 CPU、内存、磁盘和网络
+
+| 问题 | 常用命令 |
+|------|----------|
+| CPU/负载 | `top`、`uptime`、`mpstat` |
+| 进程内存 | `ps`、`top`、`pmap -x PID` |
+| 系统内存 | `free -h`、`vmstat` |
+| 磁盘容量 | `df -h` |
+| 目录占用 | `du -sh PATH`、`du -h --max-depth=1` |
+| 文件 I/O | `iostat`、`iotop` |
+| 监听端口 | `ss -lntp` |
+| 连接测试 | `curl -v URL`、`nc -vz HOST PORT` |
+
+“内存不够”至少可能指主机 RAM、GPU 显存、共享内存 `/dev/shm`、进程地址空间限制或磁盘满。先确认资源种类再行动。
+
+### 7.6 环境变量与动态库路径
+
+```bash
+export CUDA_HOME=/usr/local/cuda
+export PATH="$CUDA_HOME/bin:$PATH"
+export LD_LIBRARY_PATH="$CUDA_HOME/lib64:${LD_LIBRARY_PATH:-}"
+
+env | sort
+which nvcc
+type -a python
+```
+
+环境变量由父进程传给子进程。修改 `~/.bashrc` 不会神奇地改变已经运行的终端、IDE 或服务；需要重新加载配置或重启相应进程。
+
+使用 `env -i` 可以在近乎空白的环境中复现问题，但要显式补充必要变量：
+
+```bash
+env -i HOME="$HOME" PATH=/usr/bin:/bin bash --noprofile --norc
+```
+
+### 7.7 SSH 与文件传输
+
+生成密钥并配置登录：
+
+```bash
+ssh-keygen -t ed25519 -C "your-name"
+ssh-copy-id user@server
+ssh user@server
+```
+
+`~/.ssh/config` 可保存别名：
+
+```text
+Host gpu-dev
+    HostName 192.0.2.10
+    User lxy
+    IdentityFile ~/.ssh/id_ed25519
+    ServerAliveInterval 60
+```
+
+之后直接 `ssh gpu-dev`。同步大目录优先使用支持增量传输的 `rsync`：
+
+```bash
+rsync -av --progress ./project/ gpu-dev:~/project/
+```
+
+同步前仔细检查源路径末尾的 `/`，它会影响复制“目录本身”还是“目录内容”。敏感数据和私钥不要放进仓库或随意传到共享机器。
+
+### 7.8 调试原生程序
+
+编译时加入调试信息：
+
+```bash
+g++ -g -O0 main.cpp -o app
+gdb ./app
+```
+
+GDB 基本操作：
+
+```text
+break main       # 设置断点
+run              # 启动
+next / step      # 单步，是否进入函数
+print variable   # 查看变量
+bt               # 查看调用栈
+continue         # 继续运行
+```
+
+优化版崩溃也应保留符号信息，例如 `-O2 -g`，这样 core dump 才有可读调用栈。调试器回答“在哪里崩”，Sanitizer 更擅长回答“哪次非法内存操作造成了它”。
+
+系统调用层的问题可以用 `strace`（Linux）观察：
+
+```bash
+strace -f -o trace.log ./app
+rg 'ENOENT|EACCES' trace.log
+```
+
+这对定位“程序到底在找哪个配置文件/动态库”非常有效。
+
+---
+
+## 8. 环境隔离与 GPU 软件栈
+
+### 8.1 `venv`、conda 与容器解决不同层次的问题
+
+| 工具 | 隔离范围 | 适合场景 |
+|------|----------|----------|
+| `venv` | Python 包与解释器环境 | 纯 Python 项目、依赖简单 |
+| conda | Python + 一部分原生库与工具链 | 科学计算、复杂二进制依赖 |
+| Docker/容器 | 用户态文件系统、依赖与进程环境 | 部署、CI、跨机器复现 |
+
+`venv` 示例：
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt
+```
+
+始终用 `python -m pip` 可以减少“运行的是 A 环境的 Python，却调用 B 环境的 pip”这类混淆。
+
+conda 示例：
+
+```bash
+conda create -n ai-infra python=3.12
+conda activate ai-infra
+conda env export --from-history > environment.yml
+```
+
+锁定直接依赖版本有助于复现，但完整环境还包括操作系统、驱动、编译器、硬件架构和启动参数。不要把一个 `requirements.txt` 当成全部环境描述。
+
+### 8.2 容器不是虚拟机
+
+容器与宿主机共享内核，只隔离用户态文件系统、进程、网络等资源。GPU 容器通常仍使用**宿主机 NVIDIA 驱动**，再通过 NVIDIA Container Toolkit 把设备和驱动库暴露给容器。
+
+```bash
+docker run --rm -it \
+  --gpus all \
+  -v "$PWD:/workspace" \
+  -w /workspace \
+  nvidia/cuda:12.4.1-runtime-ubuntu22.04 \
+  nvidia-smi
+```
+
+镜像 tag 应固定到足够具体的版本。卷挂载会让容器内进程直接修改宿主目录，运行陌生命令前要理解挂载和用户权限。
+
+### 8.3 GPU 软件栈：四个容易混淆的部分
+
+```text
+应用 / PyTorch / 自定义扩展
+        │
+CUDA Runtime 与数学库（cudart、cuBLAS、cuDNN 等）
+        │
+用户态驱动库（libcuda）
+        │
+内核态 NVIDIA Driver
+        │
+GPU
+```
+
+- **NVIDIA Driver**：操作系统与 GPU 通信的基础；`nvidia-smi` 主要反映驱动状态；
+- **CUDA Toolkit**：开发工具集合，包含 `nvcc`、头文件、调试/分析工具和库；
+- **CUDA Runtime/数学库**：应用运行时加载的用户态组件；
+- **cuDNN**：面向深度学习算子的独立加速库，不等于整个 CUDA。
+
+`nvidia-smi` 显示的“CUDA Version”通常表示驱动可支持的最高 CUDA 兼容级别，并不证明本机安装了同版本 `nvcc`。判断编译工具链要看 `nvcc --version`，判断框架实际使用的运行时要看框架自身信息。
+
+### 8.4 诊断 GPU 环境的固定顺序
+
+```bash
+# 1. 驱动是否看到设备
+nvidia-smi
+
+# 2. 编译工具链来自哪里
+which nvcc
+nvcc --version
+
+# 3. Python 与框架来自哪里
+which python
+python -c 'import sys; print(sys.executable)'
+
+# 4. 框架看到什么
+python - <<'PY'
+import torch
+print("torch:", torch.__version__)
+print("built with CUDA:", torch.version.cuda)
+print("CUDA available:", torch.cuda.is_available())
+print("device count:", torch.cuda.device_count())
+PY
+```
+
+常见现象的含义：
+
+| 现象 | 优先检查 |
+|------|----------|
+| `nvidia-smi` 失败 | 驱动、设备挂载、宿主机状态 |
+| `nvidia-smi` 成功但找不到 `nvcc` | Toolkit 未装或 `PATH` 错；运行预编译框架未必需要 `nvcc` |
+| 框架导入成功但 CUDA 不可用 | 安装了 CPU 构建、驱动兼容、容器未传 GPU、设备被屏蔽 |
+| 自定义扩展编译失败 | 编译器、Toolkit、头文件、ABI、目标 GPU 架构 |
+| 运行时报缺 `.so` | 动态库搜索路径、wheel/conda 依赖、架构不匹配 |
+
+一次只改变一个变量，并保留原始报错。大多数环境问题都能通过这条链路定位，无需“全删重装”。
+
+---
+
+## 9. Git 协作与问题定位方法
+
+### 9.1 一条干净的贡献流程
+
+```bash
+git clone https://github.com/owner/project.git
+cd project
+git switch -c docs/improve-foundations
+
+# 修改并验证
+git status --short
+git diff --check
+git diff
+
+git add path/to/changed-file
+git commit -m "docs: expand programming foundations"
+```
+
+提交应只包含一个清晰主题。不要把格式化整个仓库、编辑器配置和目标改动混在一起。
+
+### 9.2 读懂工作区状态
+
+Git 需要区分三层：
+
+```text
+HEAD 中的提交  ← git commit ← 暂存区 ← git add ← 工作区
+```
+
+```bash
+git diff                 # 工作区 vs 暂存区
+git diff --staged        # 暂存区 vs HEAD
+git status --short
+git log --oneline --decorate -10
+```
+
+在提交前同时看 `git diff` 与 `git diff --staged`，可避免漏提交或把无关文件带入。
+
+### 9.3 合并、变基与冲突
+
+- `merge` 保留两条分支历史并创建合并提交；
+- `rebase` 把本分支提交重新播放到新基线，历史线性，但会改写提交 ID。
+
+个人尚未共享的功能分支可以 rebase；公共分支不要随意改写历史。冲突解决不是机械删除标记，而是理解双方意图、保留正确组合并重新运行测试。
+
+### 9.4 一个可复用的定位框架
+
+遇到问题时按以下顺序记录：
+
+1. **期望行为**：应该发生什么；
+2. **实际行为**：完整报错、退出码、错误输出；
+3. **最小复现**：最短命令、最小输入；
+4. **环境**：代码提交、依赖版本、系统、硬件；
+5. **边界定位**：数据、Python、C++、CUDA、驱动、网络中的哪一层；
+6. **单变量实验**：每次只改变一项并记录结果。
+
+“偶尔 OOM”不是可执行的问题描述；“提交 abc123、batch size 8、序列长度 4096，在第 23 step 分配 1.2 GiB 时 CUDA OOM，batch size 4 不复现”才是。
+
+---
+
+## 10. 综合实战：给 Python 添加一个 C++ 算子
+
+下面用 `pybind11` 实现逐元素缩放，完整走过源码、构建、导入和验证。这个例子只为了展示跨语言链路；真正的数值计算应优先使用成熟向量化库。
+
+### 10.1 项目结构
+
+```text
+fast_scale/
+├── CMakeLists.txt
+├── scale.cpp
+└── test_scale.py
+```
+
+### 10.2 C++ 实现与绑定
+
+```cpp
+// scale.cpp
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <vector>
+
+std::vector<float> scale(const std::vector<float>& input, float factor) {
+    std::vector<float> output;
+    output.reserve(input.size());
+    for (float value : input) {
+        output.push_back(value * factor);
+    }
+    return output;
+}
+
+PYBIND11_MODULE(fast_scale, module) {
+    module.def("scale", &scale,
+               pybind11::arg("input"),
+               pybind11::arg("factor"));
+}
+```
+
+这里使用 `const std::vector<float>&` 避免函数内部再复制输入，但 Python 列表转换成 `std::vector` 时仍会产生一次边界转换；返回值也会转换为 Python 列表。这不是零拷贝。
+
+### 10.3 CMake 构建
+
+```cmake
+cmake_minimum_required(VERSION 3.20)
+project(fast_scale LANGUAGES CXX)
+
+find_package(Python COMPONENTS Interpreter Development REQUIRED)
+find_package(pybind11 CONFIG REQUIRED)
+
+pybind11_add_module(fast_scale scale.cpp)
+target_compile_features(fast_scale PRIVATE cxx_std_17)
+```
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install pybind11
+
+cmake -S . -B build \
+  -Dpybind11_DIR="$(python -m pybind11 --cmakedir)" \
+  -DCMAKE_BUILD_TYPE=Release
+cmake --build build --parallel
+```
+
+### 10.4 验证正确性
+
+```python
+# test_scale.py
+import sys
+
+sys.path.insert(0, "build")
+import fast_scale
+
+actual = fast_scale.scale([1.0, -2.0, 3.5], 2.0)
+expected = [2.0, -4.0, 7.0]
+assert actual == expected
+print(actual)
+```
+
+```bash
+python test_scale.py
+```
+
+### 10.5 从教学例子到高性能接口还差什么
+
+这个例子没有比 Python 列表推导式更有优势，因为边界上发生了逐元素转换。真正的高性能扩展还要考虑：
+
+1. 接收 NumPy/PyTorch 连续缓冲区而不是 Python 列表；
+2. 校验 dtype、shape、stride 与 device；
+3. 避免不必要复制，并明确所有权；
+4. 大计算期间释放 GIL；
+5. 为 CPU 向量化或 CUDA 提供批量实现；
+6. 对比可信参考实现，测试边界输入；
+7. 分开测量边界转换和核心计算。
+
+这正是后续 PyTorch 扩展、CUDA Kernel 和算子优化章节要继续解决的问题。
+
+---
+
+## 总结
+
+本章的核心不是三套孤立语法，而是一套跨层思维：
+
+- Python 中要看清对象引用、数据复制、并发模型和解释器/原生边界；
+- C++ 中要看清内存布局、生命周期、所有权、编译链接和 ABI；
+- Linux 中要看清进程、资源、路径、权限、动态库和环境继承；
+- 性能问题先测量再优化，环境问题沿软件栈逐层验证；
+- 一个好接口不仅描述“传什么值”，还应描述类型、形状、布局、设备、所有权与生命周期。
+
+后续学习 CUDA、PyTorch、分布式训练和推理框架时，你会不断遇到这些概念，只是它们换成了 GPU 显存、Stream、Tensor、通信进程和模型服务的形式。
+
+## 自我检验清单
+
+- [ ] 能解释 `is` 与 `==`、浅拷贝与深拷贝的区别
+- [ ] 能说明默认可变参数为什么会跨调用共享
+- [ ] 能写一个保留函数元信息的装饰器和一个上下文管理器
+- [ ] 能根据 I/O 密集、CPU 密集选择线程、进程或异步 I/O
+- [ ] 知道 GPU 异步执行为什么会让普通 CPU 计时失真
+- [ ] 能区分 C++ 指针、引用、值和 `const` 引用的接口语义
+- [ ] 能说明 RAII、`unique_ptr`、`shared_ptr` 各自解决什么问题
+- [ ] 能解释预处理、编译、汇编、链接和动态装载阶段
+- [ ] 能用 CMake 构建一个最小 C++ 库
+- [ ] 能解释 shape、stride、dtype、device 和 lifetime 为什么属于跨语言接口
+- [ ] 能在 Linux 上查进程、资源占用、端口和动态库依赖
+- [ ] 能区分 NVIDIA Driver、CUDA Toolkit、CUDA Runtime 与 cuDNN
+- [ ] 能创建小而清晰的 Git 分支和提交，并在提交前检查 diff
+- [ ] 能用“最小复现 + 环境快照 + 单变量实验”定位问题
+
+## 练习题
+
+1. 写一段代码复现浅拷贝共享内层列表的问题，并分别用数据重构和深拷贝修复。
+2. 实现带参数的 `@retry(max_attempts=3)` 装饰器，只捕获调用方指定的异常类型。
+3. 分别用线程池和进程池执行 I/O 等待任务、纯 Python CPU 任务，记录并解释耗时差异。
+4. 用 `cProfile` 分析一个脚本，找出累计耗时最高的三个函数；优化其中一个并重新测量。
+5. 写一个持有文件句柄的 C++ RAII 类，禁用复制并支持移动。
+6. 故意制造一次堆越界，分别观察普通运行和 AddressSanitizer 的报错差异。
+7. 把一个 C++ 库拆成头文件、源文件和可执行程序，用 target-based CMake 构建。
+8. 用 `ldd`/`otool -L` 与 `nm -C` 分析一个 Python 原生扩展的依赖和导出符号。
+9. 在干净虚拟环境中安装 PyTorch，记录 `sys.executable`、框架版本、构建 CUDA 版本和设备可见性。
+10. 改造综合实战：接收 NumPy 数组，检查 dtype 与连续性，并比较复制版和共享缓冲区版的耗时。
+
+## 参考资料
+
+- [Python 官方教程](https://docs.python.org/3/tutorial/)
+- [Python Data Model](https://docs.python.org/3/reference/datamodel.html)
+- [Python `concurrent.futures`](https://docs.python.org/3/library/concurrent.futures.html)
+- [Python `asyncio`](https://docs.python.org/3/library/asyncio.html)
+- [Python Profilers](https://docs.python.org/3/library/profile.html)
+- [C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines)
+- [CMake 官方教程](https://cmake.org/cmake/help/latest/guide/tutorial/)
+- [pybind11 官方文档](https://pybind11.readthedocs.io/)
+- [GNU GDB 文档](https://sourceware.org/gdb/documentation/)
+- [Git 官方文档](https://git-scm.com/doc)
+- [Docker 官方文档](https://docs.docker.com/)
+- [NVIDIA CUDA Installation Guide for Linux](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/)

--- a/docs/guides/模块一-前置知识/第2章-数学基础.md
+++ b/docs/guides/模块一-前置知识/第2章-数学基础.md
@@ -7,12 +7,1891 @@ order: 2
 tags: ["线性代数", "概率论", "微积分", "数学基础"]
 ---
 
-## 本章简介
+AI Infra 不要求每天手推复杂定理，但要求看到公式时能立刻回答三个工程问题：**张量是什么形状、需要多少计算和存储、怎样实现才稳定**。
 
-本章建立后续学习所需的数学直觉，不追求严格的数学推导，而是聚焦"够用且能关联到工程实践"的程度。
+本章围绕这三个问题建立数学直觉。我们会从向量和矩阵开始，连接到 GEMM 与分块；从概率分布开始，连接到 Softmax、交叉熵和采样；从链式法则开始，连接到反向传播；最后讨论浮点数、误差和混合精度。目标不是证明所有结论，而是做到“公式能读、维度能推、数量级能估、数值风险能判断”。
 
-**线性代数**部分重点掌握矩阵运算和维度推导直觉（看到 `(B, S, H) × (H, V)` 能立刻知道结果维度），理解分块矩阵运算（GEMM tiling 的数学基础）和 SVD 的低秩近似直觉（为后续 LoRA、MLA 做准备）。
+<!-- more -->
 
-**概率论与统计**部分覆盖 Softmax 的概率解释、交叉熵损失推导和 KL 散度（理解 Speculative Decoding 正确性证明的前提）。
+## 📑 目录
 
-**微积分**部分了解链式法则（反向传播的数学基础）、梯度消失/爆炸的直觉，以及为什么混合精度训练中梯度会溢出。
+- [1. 学习目标、符号与三类问题](#1-学习目标符号与三类问题)
+- [2. 线性代数：张量、变换与分解](#2-线性代数张量变换与分解)
+- [3. 分块矩阵与 GEMM 工程直觉](#3-分块矩阵与-gemm-工程直觉)
+- [4. 概率论：从随机变量到模型分布](#4-概率论从随机变量到模型分布)
+- [5. Softmax、交叉熵与 KL 散度](#5-softmax交叉熵与-kl-散度)
+- [6. 微积分与反向传播](#6-微积分与反向传播)
+- [7. 优化、梯度稳定性与归一化](#7-优化梯度稳定性与归一化)
+- [8. 数值计算与混合精度](#8-数值计算与混合精度)
+- [9. AI Infra 综合算例](#9-ai-infra-综合算例)
+- [总结](#总结)
+- [自我检验清单](#自我检验清单)
+- [练习题](#练习题)
+- [参考资料](#参考资料)
+
+---
+
+## 1. 学习目标、符号与三类问题
+
+完成本章后，你应该能够：
+
+1. 区分标量、向量、矩阵和高阶张量，并熟练推导运算后的 shape；
+2. 解释点积、范数、矩阵乘法、秩、特征分解与 SVD 的直觉；
+3. 把矩阵乘法拆成 block，理解 GEMM tiling 为什么数学等价；
+4. 计算期望、方差、协方差，理解常见概率分布与条件概率；
+5. 从 logits 得到稳定的 Softmax，理解温度、交叉熵、熵和 KL 散度；
+6. 用链式法则读懂计算图，手推线性层和 Softmax 交叉熵的梯度；
+7. 解释梯度消失/爆炸、残差连接和归一化对训练的影响；
+8. 区分 FP32、TF32、FP16、BF16 与 FP8 的精度和动态范围；
+9. 识别溢出、下溢、灾难性消减、非结合性等数值风险；
+10. 估算一个算子的参数量、激活量、FLOPs、访存量与算术强度。
+
+### 1.1 本章符号
+
+| 符号 | 含义 |
+|------|------|
+| $x$ | 标量，或语境明确时的变量 |
+| $\mathbf{x}$ | 向量 |
+| $\mathbf{X}$ | 矩阵或高阶张量 |
+| $X_{ij}$ | 矩阵第 $i$ 行第 $j$ 列元素 |
+| $\mathbb{R}^{m \times n}$ | $m$ 行、$n$ 列的实矩阵集合 |
+| $\mathbf{X}^\top$ | 转置 |
+| $\mathbf{X}^{-1}$ | 逆矩阵（若存在） |
+| $\lVert \mathbf{x} \rVert_2$ | 向量的 L2 范数 |
+| $\mathbb{E}[X]$ | 期望 |
+| $\operatorname{Var}(X)$ | 方差 |
+| $\nabla_x f$ | $f$ 对 $x$ 的梯度 |
+| $\partial f / \partial x$ | 偏导数 |
+| $\odot$ | 逐元素乘法 |
+
+深度学习代码常用 batch-first 记法：
+
+- $B$：batch size；
+- $S$：sequence length；
+- $H$：hidden size；
+- $V$：vocabulary size；
+- $N_h$：attention head 数；
+- $D_h = H / N_h$：每个 head 的维度。
+
+### 1.2 读公式时先问三个问题
+
+以语言模型输出投影为例：
+
+$$
+\mathbf{Y} = \mathbf{X}\mathbf{W}, \qquad
+\mathbf{X} \in \mathbb{R}^{(BS) \times H},\quad
+\mathbf{W} \in \mathbb{R}^{H \times V}
+$$
+
+第一问，**形状是否匹配**？内维 $H$ 相同，输出是 $(BS) \times V$。
+
+第二问，**代价是多少**？每个输出元素做 $H$ 次乘加，总量约为：
+
+$$
+2BSHV \quad \text{FLOPs}
+$$
+
+这里把一次乘法和一次加法各计一个浮点操作。
+
+第三问，**实现风险是什么**？权重很大、输出 logits 很大；需要考虑数据类型、内存布局、分块、并行策略和 Softmax 的数值稳定性。
+
+这三问贯穿整个 AI Infra 技术栈。
+
+---
+
+## 2. 线性代数：张量、变换与分解
+
+### 2.1 标量、向量、矩阵和张量
+
+- **标量**是一个数，如学习率 $\eta = 10^{-4}$；
+- **向量**是一维有序数组，如一个 token 的隐藏状态 $\mathbf{x} \in \mathbb{R}^{H}$；
+- **矩阵**是二维数组，如线性层权重 $\mathbf{W} \in \mathbb{R}^{H \times 4H}$；
+- **张量**是多维数组，如一批序列的隐藏状态 $\mathbf{X} \in \mathbb{R}^{B \times S \times H}$。
+
+工程中的“张量”还带有数学 shape 之外的信息：
+
+```text
+数据地址 + shape + stride + dtype + device + layout
+```
+
+两个张量 shape 相同，不代表内存布局相同；数值相同，也不代表 dtype 和误差特性相同。
+
+### 2.2 Shape、索引和 stride
+
+考虑一个 shape 为 $(2, 3)$ 的行主序矩阵：
+
+$$
+\mathbf{X} =
+\begin{bmatrix}
+1 & 2 & 3 \\
+4 & 5 & 6
+\end{bmatrix}
+$$
+
+底层连续存储为 `[1, 2, 3, 4, 5, 6]`，以元素为单位的 stride 是 $(3, 1)$。元素 $X_{ij}$ 的线性偏移为：
+
+$$
+\text{offset}(i,j) = 3i + j
+$$
+
+转置视图 $\mathbf{X}^\top$ 的 shape 是 $(3,2)$，stride 变成 $(1,3)$，通常无需复制数据。但按转置后的最后一维扫描时，访问不再连续。
+
+`reshape` 是否复制取决于原 layout 能否用新 shape/stride 表示。看到 `view`、`reshape`、`transpose`、`contiguous` 时，都要同时思考逻辑维度和物理布局。
+
+### 2.3 逐元素运算与广播
+
+逐元素加法要求对应元素能配对：
+
+$$
+\mathbf{C} = \mathbf{A} + \mathbf{B}, \qquad C_{ij} = A_{ij} + B_{ij}
+$$
+
+广播允许某些长度为 1 或缺失的维度被逻辑扩展。例如：
+
+$$
+\mathbf{X} \in \mathbb{R}^{B \times S \times H}, \qquad
+\mathbf{b} \in \mathbb{R}^{H}
+$$
+
+$\mathbf{X}+\mathbf{b}$ 会在 batch 和 sequence 维复用同一个 bias，结果 shape 仍为 $(B,S,H)$。
+
+从尾部维度向前对齐时，每对维度必须满足：
+
+1. 两者大小相等；或
+2. 至少一个大小为 1；或
+3. 某一方不存在该维度。
+
+广播通常是逻辑视图，不会先复制出完整张量。但后续 Kernel 的访存和归约模式仍会受影响。更危险的是，错误 shape 也可能“恰好能广播”，代码不报错却算错语义。
+
+### 2.4 点积：相似度与加权求和
+
+两个 $n$ 维向量的点积：
+
+$$
+\mathbf{x}^\top \mathbf{y} = \sum_{i=1}^{n}x_i y_i
+$$
+
+它有两种常用直觉。
+
+**加权求和**：$\mathbf{x}$ 是权重，$\mathbf{y}$ 是值。
+
+**方向相似性**：
+
+$$
+\mathbf{x}^\top \mathbf{y}
+= \lVert \mathbf{x}\rVert_2
+  \lVert \mathbf{y}\rVert_2 \cos\theta
+$$
+
+因此余弦相似度为：
+
+$$
+\cos\theta =
+\frac{\mathbf{x}^\top\mathbf{y}}
+{\lVert\mathbf{x}\rVert_2\lVert\mathbf{y}\rVert_2}
+$$
+
+Attention 用 Query 与 Key 的点积衡量匹配程度；Embedding 检索常用归一化后的点积近似余弦相似度。
+
+如果向量范数接近 0，分母会不稳定，工程实现通常加一个很小的 $\epsilon$。
+
+### 2.5 范数：长度、误差与约束
+
+常见向量范数：
+
+$$
+\lVert \mathbf{x} \rVert_1 = \sum_i |x_i|
+$$
+
+$$
+\lVert \mathbf{x} \rVert_2 = \sqrt{\sum_i x_i^2}
+$$
+
+$$
+\lVert \mathbf{x} \rVert_\infty = \max_i |x_i|
+$$
+
+矩阵的 Frobenius 范数把所有元素视为一个长向量：
+
+$$
+\lVert \mathbf{A} \rVert_F
+= \sqrt{\sum_i\sum_j A_{ij}^2}
+$$
+
+范数在工程中用于：
+
+- 衡量参数、激活或梯度规模；
+- 梯度裁剪；
+- 比较参考实现与优化实现的误差；
+- 正则化；
+- 向量归一化。
+
+比较浮点结果时，绝对误差和相对误差各有作用：
+
+$$
+e_{abs} = |\hat{x}-x|,qquad
+e_{rel} = \frac{|\hat{x}-x|}{|x|}
+$$
+
+当参考值 $x$ 接近 0 时，相对误差会被放大，所以测试库通常组合绝对容差 `atol` 和相对容差 `rtol`：
+
+$$
+|\hat{x}-x| \le \text{atol} + \text{rtol}\cdot |x|
+$$
+
+### 2.6 矩阵乘法是一组点积
+
+若：
+
+$$
+\mathbf{A} \in \mathbb{R}^{M \times K}, \qquad
+\mathbf{B} \in \mathbb{R}^{K \times N}
+$$
+
+则：
+
+$$
+\mathbf{C} = \mathbf{A}\mathbf{B}
+\in \mathbb{R}^{M \times N}
+$$
+
+每个元素为：
+
+$$
+C_{ij} = \sum_{k=1}^{K} A_{ik}B_{kj}
+$$
+
+把形状当作接口检查：
+
+```text
+(M, K) @ (K, N) -> (M, N)
+```
+
+中间的 $K$ 被归约，外侧的 $M,N$ 保留下来。标准 GEMM 常写成：
+
+$$
+\mathbf{C} \leftarrow
+\alpha\mathbf{A}\mathbf{B} + \beta\mathbf{C}
+$$
+
+矩阵乘法一般**不满足交换律**：$\mathbf{A}\mathbf{B}$ 与 $\mathbf{B}\mathbf{A}$ 可能 shape 不同，或数值不同。但满足结合律：
+
+$$
+(\mathbf{A}\mathbf{B})\mathbf{C}
+= \mathbf{A}(\mathbf{B}\mathbf{C})
+$$
+
+数学上相等不代表浮点结果逐位相同，也不代表计算代价相同。选择不同结合顺序可以显著改变中间张量大小和 FLOPs。
+
+### 2.7 Batched Matrix Multiplication
+
+多头 Attention 中常见：
+
+$$
+\mathbf{Q} \in \mathbb{R}^{B \times N_h \times S_q \times D_h}
+$$
+
+$$
+\mathbf{K} \in \mathbb{R}^{B \times N_h \times S_k \times D_h}
+$$
+
+转置最后两维后：
+
+$$
+\mathbf{K}^\top
+\in \mathbb{R}^{B \times N_h \times D_h \times S_k}
+$$
+
+批量矩阵乘法：
+
+$$
+\mathbf{Q}\mathbf{K}^\top
+\in \mathbb{R}^{B \times N_h \times S_q \times S_k}
+$$
+
+前两维 $(B,N_h)$ 是 batch 维，每个 `(batch, head)` 独立执行一个矩阵乘法。不要把“高阶张量乘法”想得过于神秘，它通常只是对最后两维做矩阵乘法，前面的维度负责批处理和广播。
+
+### 2.8 线性变换与仿射变换
+
+严格的线性变换满足：
+
+$$
+f(a\mathbf{x}+b\mathbf{y})
+= af(\mathbf{x})+bf(\mathbf{y})
+$$
+
+矩阵乘法 $f(\mathbf{x})=\mathbf{W}\mathbf{x}$ 是线性变换。神经网络中所谓“Linear 层”通常还包含 bias：
+
+$$
+\mathbf{y}=\mathbf{W}\mathbf{x}+\mathbf{b}
+$$
+
+这在数学上是仿射变换。多个没有激活函数的线性/仿射层可以合并成一个，因此非线性激活是深层网络表达复杂函数的关键。
+
+### 2.9 转置、单位矩阵与逆矩阵
+
+转置交换行列：
+
+$$
+(\mathbf{A}^\top)_{ij} = A_{ji}
+$$
+
+常用规则：
+
+$$
+(\mathbf{A}\mathbf{B})^\top
+= \mathbf{B}^\top\mathbf{A}^\top
+$$
+
+单位矩阵 $\mathbf{I}$ 满足：
+
+$$
+\mathbf{I}\mathbf{A}=\mathbf{A}\mathbf{I}=\mathbf{A}
+$$
+
+方阵 $\mathbf{A}$ 若存在逆矩阵，则：
+
+$$
+\mathbf{A}^{-1}\mathbf{A}=
+\mathbf{A}\mathbf{A}^{-1}=\mathbf{I}
+$$
+
+求解线性方程 $\mathbf{A}\mathbf{x}=\mathbf{b}$ 时，数学上可写 $\mathbf{x}=\mathbf{A}^{-1}\mathbf{b}$，但数值实现通常不显式求逆，而使用 LU、QR、Cholesky 等分解直接求解。显式求逆往往计算更多、误差更大。
+
+### 2.10 线性相关、张成空间与秩
+
+如果一组向量中某个向量能由其他向量线性组合得到，它们线性相关。矩阵的秩（rank）可以理解为独立方向的数量：
+
+$$
+\operatorname{rank}(\mathbf{A})
+\le \min(M,N)
+$$
+
+秩低意味着矩阵中的信息存在冗余，可以由更小的两个矩阵近似：
+
+$$
+\mathbf{A} \approx
+\mathbf{U}\mathbf{V},qquad
+\mathbf{U}\in\mathbb{R}^{M\times r},
+\mathbf{V}\in\mathbb{R}^{r\times N},
+\quad r \ll \min(M,N)
+$$
+
+这会把参数量从 $MN$ 降到 $r(M+N)$，也是低秩适配和模型压缩的数学基础。
+
+### 2.11 特征值与特征向量
+
+对方阵 $\mathbf{A}$，如果存在非零向量 $\mathbf{v}$ 和标量 $\lambda$ 使：
+
+$$
+\mathbf{A}\mathbf{v}=\lambda\mathbf{v}
+$$
+
+则 $\mathbf{v}$ 是特征向量，$\lambda$ 是对应特征值。直觉上，矩阵变换在这个方向上只缩放，不改变方向。
+
+特征值可帮助理解：
+
+- 线性动态系统是否放大/衰减；
+- Hessian 在不同方向的曲率；
+- 梯度经过多层 Jacobian 连乘时为什么爆炸或消失；
+- 协方差矩阵的主要变化方向（PCA）。
+
+不是所有矩阵都能在实数域下良好特征分解；工程中应根据矩阵结构选择合适算法，而不是把 `eig` 当万能工具。
+
+### 2.12 奇异值分解（SVD）
+
+任意实矩阵 $\mathbf{A}\in\mathbb{R}^{M\times N}$ 都可以写成：
+
+$$
+\mathbf{A} = \mathbf{U}\mathbf{\Sigma}\mathbf{V}^\top
+$$
+
+其中：
+
+- $\mathbf{U}$ 的列是左奇异向量；
+- $\mathbf{V}$ 的列是右奇异向量；
+- $\mathbf{\Sigma}$ 对角线上的 $\sigma_1\ge\sigma_2\ge\cdots\ge0$ 是奇异值。
+
+保留最大的前 $r$ 个奇异值：
+
+$$
+\mathbf{A}_r
+= \mathbf{U}_{:,1:r}
+  \mathbf{\Sigma}_{1:r,1:r}
+  \mathbf{V}_{:,1:r}^\top
+$$
+
+$\mathbf{A}_r$ 是一种最优的 rank-$r$ 近似（在常见的 2-范数和 Frobenius 范数意义下）。直觉上，小奇异值对应影响较弱的方向，可以舍弃以换取压缩。
+
+SVD 本身也有计算和内存成本。大型模型权重的实际压缩通常使用截断、随机化算法或直接训练低秩因子，而不是对所有巨大矩阵做完整 SVD。
+
+### 2.13 LoRA 的低秩更新
+
+对预训练权重 $\mathbf{W}_0\in\mathbb{R}^{d_{out}\times d_{in}}$，LoRA 冻结 $\mathbf{W}_0$，只训练低秩更新：
+
+$$
+\mathbf{W} = \mathbf{W}_0 + \Delta\mathbf{W}
+$$
+
+$$
+\Delta\mathbf{W}
+= \frac{\alpha}{r}\mathbf{B}\mathbf{A}
+$$
+
+其中：
+
+$$
+\mathbf{A}\in\mathbb{R}^{r\times d_{in}},qquad
+\mathbf{B}\in\mathbb{R}^{d_{out}\times r}
+$$
+
+新增参数量从完整更新的 $d_{out}d_{in}$ 变为：
+
+$$
+r(d_{in}+d_{out})
+$$
+
+例如 $d_{in}=d_{out}=4096$、$r=16$：
+
+$$
+\frac{16(4096+4096)}{4096^2}
+= 0.0078125 \approx 0.78\%
+$$
+
+低秩只减少可训练参数与相应优化器状态，不自动消除基座权重、激活和前向计算成本。部署时可选择合并权重，或保留 adapter 动态切换，两者有不同的显存、延迟和灵活性权衡。
+
+---
+
+## 3. 分块矩阵与 GEMM 工程直觉
+
+### 3.1 为什么可以分块计算
+
+把矩阵沿 $M$、$N$ 和归约维 $K$ 切成块。以 $2\times2$ block 为例：
+
+$$
+\mathbf{A}=
+\begin{bmatrix}
+\mathbf{A}_{11} & \mathbf{A}_{12}\\
+\mathbf{A}_{21} & \mathbf{A}_{22}
+\end{bmatrix},qquad
+\mathbf{B}=
+\begin{bmatrix}
+\mathbf{B}_{11} & \mathbf{B}_{12}\\
+\mathbf{B}_{21} & \mathbf{B}_{22}
+\end{bmatrix}
+$$
+
+则：
+
+$$
+\mathbf{C}_{11}
+= \mathbf{A}_{11}\mathbf{B}_{11}
++ \mathbf{A}_{12}\mathbf{B}_{21}
+$$
+
+$$
+\mathbf{C}_{12}
+= \mathbf{A}_{11}\mathbf{B}_{12}
++ \mathbf{A}_{12}\mathbf{B}_{22}
+$$
+
+其他块同理。每个输出块沿 $K$ 方向累加若干局部乘积。因此 GPU Kernel 可以：
+
+1. 取一小块 $\mathbf{A}$ 和一小块 $\mathbf{B}$；
+2. 搬到片上共享内存/寄存器；
+3. 重复使用这些数据计算多个输出元素；
+4. 沿 $K$ 方向迭代并累加；
+5. 最后把输出块写回 HBM。
+
+这就是 tiling 的数学依据。它改变计算顺序和数据搬运，不改变目标公式。
+
+### 3.2 朴素 GEMM 的计算与访存
+
+对于 $(M,K)@(K,N)$：
+
+- 输出元素数：$MN$；
+- 每个元素执行 $K$ 次乘加；
+- FLOPs 约为 $2MKN$。
+
+朴素实现若每次乘加都从全局内存加载 $A_{ik}$ 和 $B_{kj}$，同一个元素会被大量重复读取。GEMM 的高性能来自数据复用：
+
+- $A$ 的一个元素被同一输出行的多个列复用；
+- $B$ 的一个元素被同一输出列的多个行复用；
+- 累加器在寄存器中复用 $K$ 次。
+
+### 3.3 一个简化的算术强度估算
+
+算术强度定义为：
+
+$$
+\text{Arithmetic Intensity}
+= \frac{\text{FLOPs}}{\text{bytes transferred from target memory}}
+$$
+
+理想情况下，FP16 GEMM 每个输入矩阵只从 HBM 读一次，输出写一次，粗略字节数为：
+
+$$
+2(MK+KN+MN)
+$$
+
+于是：
+
+$$
+AI \approx
+\frac{2MKN}{2(MK+KN+MN)}
+$$
+
+实际还有 cache、对齐、读改写、临时结果和融合操作。这个估算不是精确性能模型，但能帮助判断算子更可能受算力还是带宽限制。
+
+### 3.4 tile 不是越大越好
+
+更大的 tile 提高数据复用，却会消耗更多：
+
+- 共享内存；
+- 寄存器；
+- 每个 block 的线程和同步；
+- 边界处理成本。
+
+资源占用过高会降低一个 SM 同时驻留的 block/warp 数量，影响延迟隐藏。tile 选择是在数据复用、占用率、指令效率和形状适配之间折中。
+
+### 3.5 尾块与 padding
+
+当 $M,N,K$ 不是 tile size 的整数倍时，最后一块会越过有效边界。常见做法：
+
+- 加边界判断/掩码；
+- 把输入 padding 到对齐尺寸；
+- 为常见整齐 shape 提供快路径，其他 shape 走通用路径。
+
+padding 会增加计算和存储，分支会增加控制开销。哪种方式更快取决于 shape 和硬件。
+
+### 3.6 浮点分块结果为什么可能不同
+
+实数加法满足结合律，但浮点加法不严格满足：
+
+$$
+(a+b)+c \ne a+(b+c)
+$$
+
+不同 tile、线程归约树、Tensor Core 路径会改变累加顺序，所以优化前后结果可能不逐位一致。正确性验证应使用适合 dtype 和问题规模的误差容限，并关注误差是否随归约长度系统性放大。
+
+---
+
+## 4. 概率论：从随机变量到模型分布
+
+### 4.1 随机变量和概率分布
+
+随机变量把随机结果映射为数。离散随机变量用概率质量函数：
+
+$$
+p_X(x)=P(X=x),qquad \sum_x p_X(x)=1
+$$
+
+连续随机变量用概率密度函数：
+
+$$
+p_X(x)\ge0,qquad
+\int_{-\infty}^{\infty}p_X(x)\,dx=1
+$$
+
+连续变量在单点的概率通常为 0，区间概率由密度积分得到。模型里常见分布：
+
+| 分布 | 取值 | 典型场景 |
+|------|------|----------|
+| Bernoulli | $0/1$ | 二分类、Dropout mask |
+| Categorical | $1,\ldots,V$ | 下一个 token 分布 |
+| Uniform | 区间/有限集合 | 初始化、随机采样 |
+| Gaussian | 实数 | 初始化、噪声、近似分析 |
+
+### 4.2 联合概率、边缘概率与条件概率
+
+联合概率描述多个事件同时发生：
+
+$$
+P(X=x,Y=y)
+$$
+
+对另一个变量求和或积分得到边缘概率：
+
+$$
+P(X=x)=\sum_y P(X=x,Y=y)
+$$
+
+条件概率：
+
+$$
+P(X=x\mid Y=y)
+= \frac{P(X=x,Y=y)}{P(Y=y)}
+$$
+
+自回归语言模型用链式法则分解序列概率：
+
+$$
+P(x_1,x_2,\ldots,x_T)
+= \prod_{t=1}^{T}P(x_t\mid x_1,\ldots,x_{t-1})
+$$
+
+这解释了训练时的 next-token prediction 和推理时逐 token 生成为什么是同一概率模型的两个过程。
+
+### 4.3 独立与条件独立
+
+若：
+
+$$
+P(X,Y)=P(X)P(Y)
+$$
+
+则 $X,Y$ 独立。独立比“不相关”更强；协方差为 0 不一定独立。
+
+给定 $Z$ 后条件独立写作：
+
+$$
+P(X,Y\mid Z)=P(X\mid Z)P(Y\mid Z)
+$$
+
+分布式采样、数据并行和统计估计常隐含独立同分布（i.i.d.）假设。真实数据中的重复样本、分片偏差或序列相关性可能破坏该假设。
+
+### 4.4 Bayes 公式
+
+$$
+P(X\mid Y)
+= \frac{P(Y\mid X)P(X)}{P(Y)}
+$$
+
+其中 $P(X)$ 是先验，$P(Y\mid X)$ 是似然，$P(X\mid Y)$ 是后验。虽然常规 LLM 训练不直接手算 Bayes 公式，但它是概率推断、参数估计和不确定性建模的基础。
+
+### 4.5 期望：概率加权平均
+
+离散变量：
+
+$$
+\mathbb{E}[X]=\sum_x xP(X=x)
+$$
+
+连续变量：
+
+$$
+\mathbb{E}[X]=\int x p(x)\,dx
+$$
+
+期望具有线性性质，不要求变量独立：
+
+$$
+\mathbb{E}[aX+bY]
+= a\mathbb{E}[X]+b\mathbb{E}[Y]
+$$
+
+训练目标通常是对数据分布的期望损失：
+
+$$
+\min_\theta
+\mathbb{E}_{(x,y)\sim p_{data}}
+[\mathcal{L}(f_\theta(x),y)]
+$$
+
+实际无法遍历真实分布，于是用 mini-batch 样本均值近似。
+
+### 4.6 方差与标准差
+
+方差衡量围绕均值的波动：
+
+$$
+\operatorname{Var}(X)
+= \mathbb{E}[(X-\mu)^2]
+= \mathbb{E}[X^2]-\mu^2
+$$
+
+标准差与原变量单位相同：
+
+$$
+\sigma = \sqrt{\operatorname{Var}(X)}
+$$
+
+若 $X,Y$ 独立：
+
+$$
+\operatorname{Var}(X+Y)
+= \operatorname{Var}(X)+\operatorname{Var}(Y)
+$$
+
+训练中的梯度噪声、初始化尺度、归一化和量化误差都与方差有关。
+
+### 4.7 协方差与相关系数
+
+协方差衡量两个变量共同变化：
+
+$$
+\operatorname{Cov}(X,Y)
+= \mathbb{E}[(X-\mu_X)(Y-\mu_Y)]
+$$
+
+标准化得到相关系数：
+
+$$
+\rho_{X,Y}
+= \frac{\operatorname{Cov}(X,Y)}{\sigma_X\sigma_Y}
+$$
+
+对向量随机变量，协方差矩阵为：
+
+$$
+\mathbf{\Sigma}
+= \mathbb{E}[(\mathbf{x}-\boldsymbol{\mu})
+(\mathbf{x}-\boldsymbol{\mu})^\top]
+$$
+
+它是对称半正定矩阵。PCA 对协方差矩阵做特征分解，找出数据方差最大的正交方向。
+
+### 4.8 样本均值、方差与 mini-batch
+
+给定样本 $x_1,\ldots,x_n$，样本均值：
+
+$$
+\bar{x}=\frac{1}{n}\sum_{i=1}^{n}x_i
+$$
+
+常用无偏样本方差：
+
+$$
+s^2=\frac{1}{n-1}\sum_{i=1}^{n}(x_i-\bar{x})^2
+$$
+
+深度学习算子中的“方差”是否除以 $n$ 还是 $n-1$ 取决于具体定义。LayerNorm 通常使用总体方差形式（除以元素数量），统计库的默认值可能不同。复现算子时要查 API 语义，不要只看名字。
+
+### 4.9 最大似然与负对数似然
+
+给定数据 $D=\{(x_i,y_i)\}$，最大似然估计选择让观测数据最可能的参数：
+
+$$
+\theta^*
+= \arg\max_\theta
+\prod_i p_\theta(y_i\mid x_i)
+$$
+
+乘积容易数值下溢，且不便求导。取对数把乘积变成求和：
+
+$$
+\theta^*
+= \arg\max_\theta
+\sum_i \log p_\theta(y_i\mid x_i)
+$$
+
+等价地最小化负对数似然（NLL）：
+
+$$
+\mathcal{L}_{NLL}
+= -\sum_i \log p_\theta(y_i\mid x_i)
+$$
+
+对数是数值计算和概率建模之间的重要桥梁。
+
+---
+
+## 5. Softmax、交叉熵与 KL 散度
+
+### 5.1 Logits 不是概率
+
+模型最后一层输出 $V$ 个任意实数：
+
+$$
+\mathbf{z}=(z_1,z_2,\ldots,z_V)
+$$
+
+这些值叫 logits。它们可以为负，也不要求和为 1。Softmax 把它们转换为分类分布：
+
+$$
+p_i = \operatorname{softmax}(\mathbf{z})_i
+= \frac{e^{z_i}}{\sum_{j=1}^{V}e^{z_j}}
+$$
+
+显然 $p_i>0$ 且 $\sum_i p_i=1$。
+
+Softmax 对统一平移不敏感：
+
+$$
+\operatorname{softmax}(\mathbf{z}+c)
+= \operatorname{softmax}(\mathbf{z})
+$$
+
+因为分子分母都会乘以 $e^c$。这个性质正是稳定实现的依据。
+
+### 5.2 数值稳定的 Softmax
+
+若直接计算 $e^{1000}$，有限精度浮点数会溢出。令：
+
+$$
+m=\max_j z_j
+$$
+
+稳定形式为：
+
+$$
+p_i=
+\frac{e^{z_i-m}}
+{\sum_j e^{z_j-m}}
+$$
+
+最大的指数输入为 0，因此最大指数值为 1；其他值不大于 1。伪代码：
+
+```python
+def stable_softmax(x):
+    maximum = max(x)
+    exps = [exp(value - maximum) for value in x]
+    denominator = sum(exps)
+    return [value / denominator for value in exps]
+```
+
+减最大值防止正向溢出，但很小的项仍可能下溢到 0。这通常代表它相对最大项确实可以忽略；如果后续还要取对数，则应直接使用稳定的 `log_softmax`，避免先变成 0 再 `log(0)`。
+
+### 5.3 LogSumExp
+
+定义：
+
+$$
+\operatorname{LSE}(\mathbf{z})
+= \log\sum_j e^{z_j}
+$$
+
+稳定形式：
+
+$$
+\operatorname{LSE}(\mathbf{z})
+= m + \log\sum_j e^{z_j-m}
+$$
+
+于是：
+
+$$
+\log\operatorname{softmax}(\mathbf{z})_i
+= z_i - \operatorname{LSE}(\mathbf{z})
+$$
+
+交叉熵实现通常融合 `log_softmax + NLLLoss`，既减少中间张量和访存，也避免不稳定的“先 Softmax 再取 log”。
+
+### 5.4 温度参数
+
+带温度 $T>0$ 的 Softmax：
+
+$$
+p_i(T)=
+\frac{e^{z_i/T}}{\sum_j e^{z_j/T}}
+$$
+
+- $T<1$：放大 logit 差异，分布更尖锐；
+- $T>1$：缩小差异，分布更平坦；
+- $T\to0^+$：逐渐接近只选择最大 logit；
+- $T\to\infty$：逐渐接近均匀分布。
+
+温度改变的是采样分布，不等于修改模型权重。工程实现应先缩放 logits，再应用稳定 Softmax，并谨慎处理非常小的温度。
+
+### 5.5 交叉熵
+
+真实分布 $\mathbf{q}$ 与模型分布 $\mathbf{p}$ 的交叉熵：
+
+$$
+H(\mathbf{q},\mathbf{p})
+= -\sum_i q_i\log p_i
+$$
+
+若真实标签是 one-hot，正确类别为 $y$：
+
+$$
+q_y=1,\quad q_{i\ne y}=0
+$$
+
+则：
+
+$$
+\mathcal{L}
+= -\log p_y
+$$
+
+模型给正确类别越高概率，损失越小。若 $p_y=1$，损失为 0；若 $p_y$ 接近 0，损失很大。
+
+### 5.6 信息熵
+
+分布自身的熵：
+
+$$
+H(\mathbf{p})
+= -\sum_i p_i\log p_i
+$$
+
+熵衡量不确定性：
+
+- 全部概率集中在一个类别时，熵最小；
+- $V$ 个类别均匀分布时，熵最大，为 $\log V$。
+
+对数底决定单位：自然对数对应 nat，以 2 为底对应 bit。机器学习损失通常使用自然对数。
+
+### 5.7 KL 散度
+
+从分布 $\mathbf{q}$ 到 $\mathbf{p}$ 的 KL 散度：
+
+$$
+D_{KL}(\mathbf{q}\lVert\mathbf{p})
+= \sum_i q_i\log\frac{q_i}{p_i}
+$$
+
+它满足：
+
+$$
+D_{KL}(\mathbf{q}\lVert\mathbf{p})\ge0
+$$
+
+且两分布相同时为 0。但它通常不对称：
+
+$$
+D_{KL}(\mathbf{q}\lVert\mathbf{p})
+\ne D_{KL}(\mathbf{p}\lVert\mathbf{q})
+$$
+
+所以 KL 散度不是严格意义的距离。
+
+交叉熵可分解为：
+
+$$
+H(\mathbf{q},\mathbf{p})
+= H(\mathbf{q})
++ D_{KL}(\mathbf{q}\lVert\mathbf{p})
+$$
+
+训练时真实分布 $\mathbf{q}$ 固定，$H(\mathbf{q})$ 与模型参数无关，所以最小化交叉熵等价于最小化相应 KL 散度。
+
+KL 散度会出现在知识蒸馏、分布匹配、RLHF/PPO 约束和推测解码分析中。实现时要明确 API 接收的是概率、log 概率还是 logits，以及 KL 的方向。
+
+### 5.8 Perplexity
+
+若平均 token 负对数似然为 $\bar{L}$，困惑度：
+
+$$
+\operatorname{PPL}=e^{\bar{L}}
+$$
+
+它可直觉理解为模型在每一步面对的“有效候选数”。但不同 tokenizer、数据预处理、上下文长度和是否忽略特殊 token 都会影响 PPL，不能脱离评测设置直接横比。
+
+### 5.9 Top-k 与 Top-p 采样
+
+模型输出分布后，解码策略决定如何选 token：
+
+- Greedy：选择最大概率 token；
+- Top-k：只在概率最高的 $k$ 个 token 中采样；
+- Top-p（nucleus）：选择累计概率至少达到 $p$ 的最小候选集合，再归一化采样。
+
+Top-p 集合大小会随分布尖锐程度动态变化。实现时通常先过滤 logits，把被排除项设为负无穷，再执行稳定 Softmax 和采样。
+
+分布式推理若 vocabulary 被张量并行切分，global top-k/top-p 需要跨设备聚合局部候选或使用等价的分布式算法。
+
+---
+
+## 6. 微积分与反向传播
+
+### 6.1 导数：局部变化率
+
+单变量函数的导数：
+
+$$
+f'(x)=
+\lim_{h\to0}\frac{f(x+h)-f(x)}{h}
+$$
+
+导数表示在 $x$ 附近，输入微小变化如何影响输出：
+
+$$
+f(x+\Delta x)
+\approx f(x)+f'(x)\Delta x
+$$
+
+常用导数：
+
+$$
+\frac{d}{dx}x^n=nx^{n-1}
+$$
+
+$$
+\frac{d}{dx}e^x=e^x
+$$
+
+$$
+\frac{d}{dx}\log x=\frac{1}{x}
+$$
+
+### 6.2 偏导数与梯度
+
+多变量标量函数 $f(x_1,\ldots,x_n)$ 对单个变量的变化率是偏导。把所有偏导排成向量得到梯度：
+
+$$
+\nabla_{\mathbf{x}}f=
+\begin{bmatrix}
+\frac{\partial f}{\partial x_1}\\
+\vdots\\
+\frac{\partial f}{\partial x_n}
+\end{bmatrix}
+$$
+
+梯度指向函数上升最快的方向，因此梯度下降沿负梯度更新：
+
+$$
+\mathbf{x}_{t+1}
+= \mathbf{x}_t-\eta\nabla f(\mathbf{x}_t)
+$$
+
+$\eta$ 是学习率。
+
+### 6.3 Jacobian 与 Hessian
+
+向量函数 $\mathbf{y}=f(\mathbf{x})$ 的 Jacobian：
+
+$$
+\mathbf{J}_{ij}
+= \frac{\partial y_i}{\partial x_j}
+$$
+
+它描述每个输入分量对每个输出分量的局部影响。
+
+标量函数的 Hessian 是二阶偏导矩阵：
+
+$$
+\mathbf{H}_{ij}
+= \frac{\partial^2 f}
+{\partial x_i\partial x_j}
+$$
+
+Hessian 描述局部曲率。深度学习参数量太大，通常不会显式构造完整 Hessian，但 Hessian-vector product、曲率近似和特征值分析仍用于优化与稳定性研究。
+
+### 6.4 链式法则
+
+若：
+
+$$
+y=f(u),\qquad u=g(x)
+$$
+
+则：
+
+$$
+\frac{dy}{dx}
+= \frac{dy}{du}\frac{du}{dx}
+$$
+
+多层网络就是复合函数。对：
+
+$$
+\mathbf{h}_1=f_1(\mathbf{x}),quad
+\mathbf{h}_2=f_2(\mathbf{h}_1),quad
+L=f_3(\mathbf{h}_2)
+$$
+
+梯度从损失反向传播：
+
+$$
+\frac{\partial L}{\partial \mathbf{x}}
+= \frac{\partial L}{\partial \mathbf{h}_2}
+  \frac{\partial \mathbf{h}_2}{\partial \mathbf{h}_1}
+  \frac{\partial \mathbf{h}_1}{\partial \mathbf{x}}
+$$
+
+概念上是 Jacobian 连乘；实际自动微分不会显式创建巨大 Jacobian，而是高效计算 vector-Jacobian product（反向模式）。
+
+### 6.5 计算图与反向模式自动微分
+
+设：
+
+$$
+a=xy,qquad b=a+x,qquad L=b^2
+$$
+
+前向阶段保存必要中间量。反向从：
+
+$$
+\frac{\partial L}{\partial L}=1
+$$
+
+开始：
+
+$$
+\frac{\partial L}{\partial b}=2b
+$$
+
+因为 $b=a+x$：
+
+$$
+\frac{\partial L}{\partial a}=2b
+$$
+
+$x$ 有两条路径影响 $L$，梯度需要相加：
+
+$$
+\frac{\partial L}{\partial x}
+= \frac{\partial L}{\partial b}\frac{\partial b}{\partial x}
++ \frac{\partial L}{\partial a}\frac{\partial a}{\partial x}
+= 2b + 2by
+$$
+
+$$
+\frac{\partial L}{\partial y}=2bx
+$$
+
+这解释了计算图中一个张量被多处使用时为什么要累积梯度。
+
+### 6.6 线性层的反向传播
+
+采用 batch 行向量约定：
+
+$$
+\mathbf{Y}=\mathbf{X}\mathbf{W}+\mathbf{b}
+$$
+
+其中：
+
+$$
+\mathbf{X}\in\mathbb{R}^{B\times d_{in}},quad
+\mathbf{W}\in\mathbb{R}^{d_{in}\times d_{out}},quad
+\mathbf{Y}\in\mathbb{R}^{B\times d_{out}}
+$$
+
+给定上游梯度：
+
+$$
+\mathbf{G}=\frac{\partial L}{\partial \mathbf{Y}}
+\in\mathbb{R}^{B\times d_{out}}
+$$
+
+则：
+
+$$
+\frac{\partial L}{\partial \mathbf{X}}
+= \mathbf{G}\mathbf{W}^\top
+\in\mathbb{R}^{B\times d_{in}}
+$$
+
+$$
+\frac{\partial L}{\partial \mathbf{W}}
+= \mathbf{X}^\top\mathbf{G}
+\in\mathbb{R}^{d_{in}\times d_{out}}
+$$
+
+$$
+\frac{\partial L}{\partial \mathbf{b}}
+= \sum_{i=1}^{B}\mathbf{G}_{i,:}
+\in\mathbb{R}^{d_{out}}
+$$
+
+只看 shape 就能快速检查公式：
+
+```text
+dX: (B, dout) @ (dout, din) -> (B, din)
+dW: (din, B) @ (B, dout) -> (din, dout)
+db: 对 batch 维归约 -> (dout,)
+```
+
+一个线性层的反向通常包含两次 GEMM 和一次归约，这也是训练算力显著高于单次前向的原因之一。
+
+### 6.7 Softmax 的 Jacobian
+
+Softmax：
+
+$$
+p_i=\frac{e^{z_i}}{\sum_k e^{z_k}}
+$$
+
+其偏导：
+
+$$
+\frac{\partial p_i}{\partial z_j}
+= p_i(\delta_{ij}-p_j)
+$$
+
+写成矩阵：
+
+$$
+\mathbf{J}_{softmax}
+= \operatorname{diag}(\mathbf{p})
+- \mathbf{p}\mathbf{p}^\top
+$$
+
+Softmax 每个输出依赖所有输入，因此 Jacobian 不是对角矩阵。但实际反向仍可在 $O(V)$ 时间内计算，无需物化 $V\times V$ 矩阵。
+
+### 6.8 Softmax + 交叉熵的简洁梯度
+
+one-hot 标签 $\mathbf{y}$，损失：
+
+$$
+L=-\sum_i y_i\log p_i
+$$
+
+与 Softmax 联合求导后得到：
+
+$$
+\frac{\partial L}{\partial z_i}=p_i-y_i
+$$
+
+这是深度学习最重要的简化之一。对正确类别，梯度是 $p_y-1$；对其他类别，梯度是 $p_i$。预测越错，推动 logits 修正的力度越大。
+
+融合交叉熵 Kernel 可以共享最大值和归约结果、减少中间概率张量，并直接生成所需梯度。
+
+### 6.9 梯度检查
+
+自动微分实现可用有限差分做小规模检查：
+
+$$
+\frac{\partial f}{\partial x_i}
+\approx
+\frac{f(\mathbf{x}+\epsilon\mathbf{e}_i)
+-f(\mathbf{x}-\epsilon\mathbf{e}_i)}{2\epsilon}
+$$
+
+中心差分通常比单边差分准确，但 $\epsilon$ 不能太大或太小：太大有截断误差，太小会被浮点舍入误差淹没。梯度检查适合小尺寸、双精度和确定性函数，不适合直接检查带随机性或巨大张量的完整训练任务。
+
+---
+
+## 7. 优化、梯度稳定性与归一化
+
+### 7.1 全量梯度、SGD 与 mini-batch
+
+经验风险：
+
+$$
+L(\theta)=\frac{1}{N}\sum_{i=1}^{N}L_i(\theta)
+$$
+
+全量梯度每步使用所有样本，成本高。mini-batch 梯度：
+
+$$
+\hat{g}
+= \frac{1}{B}\sum_{i\in\mathcal{B}}
+\nabla_\theta L_i(\theta)
+$$
+
+是全量梯度的随机估计。基本 SGD 更新：
+
+$$
+\theta_{t+1}=\theta_t-\eta\hat{g}_t
+$$
+
+更大 batch 往往降低梯度估计方差并提高硬件利用率，但需要更多激活内存，且优化超参数可能要相应调整。
+
+### 7.2 动量
+
+一种常见动量形式：
+
+$$
+\mathbf{v}_t
+= \beta\mathbf{v}_{t-1}+(1-\beta)\mathbf{g}_t
+$$
+
+$$
+\theta_{t+1}
+= \theta_t-\eta\mathbf{v}_t
+$$
+
+动量对历史梯度做指数加权平均，减小短期噪声，在持续一致的方向上加速。
+
+### 7.3 Adam 的尺度自适应直觉
+
+Adam 同时维护一阶矩和二阶矩的指数移动平均：
+
+$$
+\mathbf{m}_t
+= \beta_1\mathbf{m}_{t-1}
++(1-\beta_1)\mathbf{g}_t
+$$
+
+$$
+\mathbf{v}_t
+= \beta_2\mathbf{v}_{t-1}
++(1-\beta_2)\mathbf{g}_t^2
+$$
+
+偏差修正后：
+
+$$
+\theta_{t+1}
+= \theta_t
+-\eta\frac{\hat{\mathbf{m}}_t}
+{\sqrt{\hat{\mathbf{v}}_t}+\epsilon}
+$$
+
+平方和开方均逐元素进行。Adam 为每个参数保存额外状态；若状态使用 FP32，内存开销往往是大模型训练的重要部分，也因此催生了 ZeRO 等分片技术。
+
+### 7.4 梯度消失与爆炸
+
+深层复合函数的梯度包含许多 Jacobian 连乘：
+
+$$
+\frac{\partial L}{\partial \mathbf{h}_0}
+= \frac{\partial L}{\partial \mathbf{h}_L}
+\prod_{l=1}^{L}
+\frac{\partial \mathbf{h}_l}
+{\partial \mathbf{h}_{l-1}}
+$$
+
+若这些变换在相关方向上的尺度长期小于 1，梯度指数衰减；长期大于 1，梯度指数增长。
+
+工程症状包括：
+
+- 梯度范数趋近 0，早期层几乎不更新；
+- 梯度范数突然巨大，loss 变为 `inf`/`nan`；
+- 混合精度下更早触发下溢或溢出。
+
+缓解手段包括合理初始化、残差连接、归一化、梯度裁剪、合适学习率和稳定的数据类型。
+
+### 7.5 残差连接为什么帮助梯度传播
+
+残差块：
+
+$$
+\mathbf{y}=\mathbf{x}+F(\mathbf{x})
+$$
+
+其 Jacobian：
+
+$$
+\frac{\partial \mathbf{y}}{\partial \mathbf{x}}
+= \mathbf{I}+\frac{\partial F}{\partial \mathbf{x}}
+$$
+
+恒等路径提供了一条不完全依赖 $F$ 的梯度通路。它不保证永远不会梯度爆炸/消失，但显著改善深层网络的优化条件。
+
+### 7.6 初始化与方差传播
+
+考虑：
+
+$$
+y=\sum_{i=1}^{n}w_i x_i
+$$
+
+若 $w_i,x_i$ 独立、均值为 0：
+
+$$
+\operatorname{Var}(y)
+= n\operatorname{Var}(w)\operatorname{Var}(x)
+$$
+
+为了让各层激活方差大致稳定，可令 $\operatorname{Var}(w)$ 与 $1/n$ 同阶。Xavier、Kaiming 初始化会根据 fan-in、fan-out 和激活函数选择尺度。
+
+初始化不是越小越稳定：过小会让信号和梯度衰减，过大则导致饱和或爆炸。
+
+### 7.7 LayerNorm
+
+对一个 token 的隐藏向量 $\mathbf{x}\in\mathbb{R}^{H}$：
+
+$$
+\mu=\frac{1}{H}\sum_{i=1}^{H}x_i
+$$
+
+$$
+\sigma^2=\frac{1}{H}
+\sum_{i=1}^{H}(x_i-\mu)^2
+$$
+
+$$
+\operatorname{LayerNorm}(x_i)
+= \gamma_i
+\frac{x_i-\mu}{\sqrt{\sigma^2+\epsilon}}
++\beta_i
+$$
+
+LayerNorm 沿隐藏维归约，不依赖 batch 中其他样本，因此适合可变序列和自回归模型。
+
+从 Kernel 角度，它至少涉及均值归约、方差归约和逐元素变换。朴素实现多次读写 HBM；优化实现会融合归约与仿射变换，并处理长向量的并行归约。
+
+### 7.8 RMSNorm
+
+RMSNorm 不减均值，只按均方根缩放：
+
+$$
+\operatorname{RMS}(\mathbf{x})
+= \sqrt{\frac{1}{H}\sum_i x_i^2+\epsilon}
+$$
+
+$$
+\operatorname{RMSNorm}(x_i)
+= \gamma_i\frac{x_i}{\operatorname{RMS}(\mathbf{x})}
+$$
+
+它减少了均值相关计算，但“公式更少”不必然按同比例提升端到端速度，实际收益取决于融合、访存和模型整体瓶颈。
+
+### 7.9 梯度裁剪
+
+全局 L2 范数裁剪：
+
+$$
+\mathbf{g}\leftarrow
+\mathbf{g}\cdot
+\min\left(1,\frac{c}{\lVert\mathbf{g}\rVert_2+\epsilon}\right)
+$$
+
+当梯度范数超过阈值 $c$ 时，整体按比例缩小，方向不变。分布式训练中，若梯度被分片，计算全局范数需要跨 rank 汇总局部平方和：
+
+$$
+\lVert\mathbf{g}\rVert_2
+= \sqrt{\sum_r\sum_{i\in r}g_i^2}
+$$
+
+因此看似简单的数学操作也会引入集合通信。
+
+---
+
+## 8. 数值计算与混合精度
+
+### 8.1 浮点数是有限集合
+
+典型二进制浮点数表示为：
+
+$$
+(-1)^s \times \text{significand}
+\times 2^{\text{exponent}}
+$$
+
+位数被分给符号、指数和尾数（有效数字）。指数位决定动态范围，尾数位决定相邻可表示数的精细程度。
+
+| 格式 | 总位数 | 指数位 | 尾数字段位 | 主要特点 |
+|------|--------|--------|------------|----------|
+| FP32 | 32 | 8 | 23 | 范围和精度较均衡 |
+| TF32 | 19（乘法输入语义） | 8 | 10 | 保留 FP32 范围，降低乘法精度，常用 FP32 累加 |
+| FP16 | 16 | 5 | 10 | 精度尚可但动态范围较小 |
+| BF16 | 16 | 8 | 7 | 接近 FP32 动态范围，精度低于 FP16 |
+| FP8 E4M3 | 8 | 4 | 3 | 精度优先、范围较小，具体编码依实现规范 |
+| FP8 E5M2 | 8 | 5 | 2 | 范围优先、精度更低，具体编码依实现规范 |
+
+表中不把隐含前导位计入尾数字段。TF32 通常是 NVIDIA Tensor Core 的计算模式，不是常规内存存储 dtype。
+
+### 8.2 精度和动态范围是两件事
+
+FP16 尾数字段比 BF16 多，因此同一数量级下通常能表示更细的差别；但 FP16 指数位少，最大有限值只有 65504，非零数的范围也窄得多。
+
+BF16 牺牲一部分精度换取与 FP32 相同的指数位数，因此训练中通常更不易溢出/下溢。它仍然会有明显舍入误差，尤其在把很小增量加到很大数上时。
+
+### 8.3 舍入与机器精度
+
+很多十进制小数不能被二进制浮点精确表示：
+
+```python
+>>> 0.1 + 0.2 == 0.3
+False
+```
+
+浮点数间距随数值绝对值增大而增大。若 $|\delta|$ 远小于当前 $x$ 附近的可表示间距：
+
+$$
+\operatorname{fl}(x+\delta)=x
+$$
+
+这就是为何优化器常保留 FP32 master weights：低精度权重上过小的更新可能被直接舍掉。
+
+### 8.4 非结合性和归约顺序
+
+由于每步都舍入：
+
+$$
+\operatorname{fl}(\operatorname{fl}(a+b)+c)
+\ne
+\operatorname{fl}(a+\operatorname{fl}(b+c))
+$$
+
+并行归约使用树形加法，不同线程数、block 划分和原子操作顺序可能产生略不同结果。非确定性不一定代表实现错误，但必须在可接受误差内，并符合任务对复现性的要求。
+
+提高归约精度的手段包括：
+
+- 用更高精度累加；
+- 成对/树形求和，避免极端尺度长期相加；
+- Kahan 等补偿求和（有额外指令成本）；
+- 先局部归约，再合并部分和。
+
+### 8.5 溢出、下溢和非有限值
+
+- **overflow**：结果绝对值超过最大有限值，常变成 $\pm\infty$；
+- **underflow**：结果太接近 0，进入 subnormal 或舍入为 0；
+- `NaN`：如 $0/0$、$\infty-\infty$ 或非法运算产生；
+- `inf` 参与后续运算可能迅速传播为 `NaN`。
+
+排查 loss 变成 `NaN` 时，应找到**第一个**非有限张量，而不是只盯最终 loss。常见源头有过大 logits、除零、负数开方、无效 mask、梯度溢出和错误的自定义 Kernel 边界。
+
+### 8.6 灾难性消减
+
+两个非常接近的大数相减时，高位有效数字抵消，剩余结果的相对误差可能巨大。例如用：
+
+$$
+\operatorname{Var}(X)
+= \mathbb{E}[X^2]-\mathbb{E}[X]^2
+$$
+
+计算方差时，两项可能都很大且接近，相减后精度损失严重。
+
+更稳定的方法包括 two-pass variance 或 Welford 在线算法。后者逐步更新均值和平方离差：
+
+$$
+n \leftarrow n+1
+$$
+
+$$
+\delta = x_n-\mu_{n-1}
+$$
+
+$$
+\mu_n = \mu_{n-1}+\frac{\delta}{n}
+$$
+
+$$
+M_{2,n}=M_{2,n-1}+\delta(x_n-\mu_n)
+$$
+
+总体方差为 $M_{2,n}/n$。Welford 还能合并不同分块的统计量，适合并行归约。
+
+### 8.7 条件数：输入误差会被放大多少
+
+问题的条件数描述输入微小扰动对输出的影响。对可逆矩阵，在某个一致范数下：
+
+$$
+\kappa(\mathbf{A})
+= \lVert\mathbf{A}\rVert
+  \lVert\mathbf{A}^{-1}\rVert
+$$
+
+条件数大表示问题病态：即使算法实现正确、输入只含很小舍入误差，输出也可能变化很大。
+
+要区分：
+
+- **问题本身是否病态**；
+- **所选算法是否数值稳定**。
+
+更多位数能缓解舍入误差，但不能从根本上消除病态问题的敏感性。
+
+### 8.8 混合精度训练的基本模式
+
+混合精度不是“把所有东西都换成 FP16”。常见模式是：
+
+1. 大型矩阵乘使用 FP16/BF16 输入，Tensor Core 加速；
+2. 乘加在 FP32 或更高的指定累加精度中完成；
+3. 归约、归一化、Softmax 等敏感操作保留或内部提升到 FP32；
+4. 优化器状态和/或 master weights 保留 FP32；
+5. 根据硬件和算子选择输出 dtype。
+
+每个框架和硬件的具体策略不同，应查实际算子文档和 profiler，而不是从输入 dtype 猜内部计算路径。
+
+### 8.9 Loss Scaling 为什么有用
+
+反向传播中的 FP16 小梯度可能下溢为 0。令缩放因子为 $S$：
+
+$$
+L' = S L
+$$
+
+则：
+
+$$
+\nabla L'=S\nabla L
+$$
+
+梯度先被放大到 FP16 可表示范围，反向完成后再除以 $S$：
+
+$$
+\nabla L=\frac{\nabla L'}{S}
+$$
+
+动态 Loss Scaling 会：
+
+1. 用当前 scale 计算反向；
+2. 检查梯度是否含 `inf`/`NaN`；
+3. 若溢出，跳过更新并减小 scale；
+4. 连续稳定若干步后尝试增大 scale。
+
+Loss Scaling 主要解决小梯度下溢，scale 过大反而会造成溢出。BF16 动态范围更大，通常不依赖 Loss Scaling，但仍可能因模型本身不稳定产生非有限值。
+
+### 8.10 稳定算法通常也更适合融合
+
+数值稳定与性能优化并不总是冲突：
+
+- Stable Softmax 先做 max 归约，再做 exp/sum 归约；Online Softmax 可合并分块状态；
+- `log_softmax + NLL` 融合减少中间概率写回；
+- Welford 同时维护统计量，适合 LayerNorm 的块级归约；
+- GEMM 用低精度输入、高精度累加兼顾吞吐与误差。
+
+关键是选择具有可组合状态的数学形式，让 Kernel 能在有限片上存储中分块处理。
+
+---
+
+## 9. AI Infra 综合算例
+
+### 9.1 算例一：Transformer 线性层的 shape 与代价
+
+输入：
+
+$$
+\mathbf{X}\in\mathbb{R}^{B\times S\times H}
+$$
+
+权重：
+
+$$
+\mathbf{W}\in\mathbb{R}^{H\times 4H}
+$$
+
+把前两维展平：
+
+$$
+\mathbf{X}'\in\mathbb{R}^{(BS)\times H}
+$$
+
+输出：
+
+$$
+\mathbf{Y}'=\mathbf{X}'\mathbf{W}
+\in\mathbb{R}^{(BS)\times 4H}
+$$
+
+再 reshape 为 $(B,S,4H)$。FLOPs：
+
+$$
+2\cdot(BS)\cdot H\cdot4H
+=8BSH^2
+$$
+
+若 $B=8,S=2048,H=4096$：
+
+$$
+8\times8\times2048\times4096^2
+\approx 2.20\times10^{12}\ \text{FLOPs}
+$$
+
+这只是一次前向线性投影，说明大模型为何高度依赖 Tensor Core GEMM。
+
+### 9.2 算例二：多头 Attention 的完整维度
+
+从：
+
+$$
+\mathbf{X}\in\mathbb{R}^{B\times S\times H}
+$$
+
+生成 Q/K/V 后 reshape 并转置：
+
+$$
+\mathbf{Q},\mathbf{K},\mathbf{V}
+\in\mathbb{R}^{B\times N_h\times S\times D_h}
+$$
+
+其中 $H=N_hD_h$。
+
+分数矩阵：
+
+$$
+\mathbf{S}
+=\frac{\mathbf{Q}\mathbf{K}^\top}{\sqrt{D_h}}
+\in\mathbb{R}^{B\times N_h\times S\times S}
+$$
+
+应用因果 mask 和 Softmax：
+
+$$
+\mathbf{P}=\operatorname{softmax}(\mathbf{S}+\mathbf{M})
+$$
+
+其中未来位置的 mask 逻辑上为 $-\infty$，使其 Softmax 概率为 0。
+
+输出：
+
+$$
+\mathbf{O}=\mathbf{P}\mathbf{V}
+\in\mathbb{R}^{B\times N_h\times S\times D_h}
+$$
+
+合并 head 后回到 $(B,S,H)$。
+
+若显式物化 FP16 的 $\mathbf{S}$，仅它就需要：
+
+$$
+2BN_hS^2\ \text{bytes}
+$$
+
+当 $B=1,N_h=32,S=32768$ 时：
+
+$$
+2\times1\times32\times32768^2
+=64\ \text{GiB}
+$$
+
+这还没算概率、反向中间量和其他层。FlashAttention 的关键就是不把完整 $S\times S$ 中间矩阵写回 HBM，而在片上分块完成稳定 Softmax 与 $PV$ 累积。
+
+### 9.3 算例三：为什么除以 $\sqrt{D_h}$
+
+假设 $q_i,k_i$ 独立、均值 0、方差 1：
+
+$$
+\mathbf{q}^\top\mathbf{k}
+=\sum_{i=1}^{D_h}q_i k_i
+$$
+
+每项 $q_i k_i$ 期望约为 0、方差约为 1，则和的方差约为 $D_h$，标准差约为 $\sqrt{D_h}$。
+
+除以 $\sqrt{D_h}$ 后，分数方差恢复到约 1：
+
+$$
+\operatorname{Var}\left(
+\frac{\mathbf{q}^\top\mathbf{k}}{\sqrt{D_h}}
+\right)\approx1
+$$
+
+避免维度增大时 logits 过度扩张，Softmax 进入极端饱和区。
+
+### 9.4 算例四：Online Softmax 的分块合并
+
+一行 logits 被切成多个 block。已处理部分的最大值和指数和为 $(m,l)$：
+
+$$
+m=\max_i x_i,qquad
+l=\sum_i e^{x_i-m}
+$$
+
+新 block 的状态为 $(m_b,l_b)$。合并最大值：
+
+$$
+m_{new}=\max(m,m_b)
+$$
+
+调整到同一基准后合并指数和：
+
+$$
+l_{new}
+= e^{m-m_{new}}l
++e^{m_b-m_{new}}l_b
+$$
+
+这使 Softmax 可以分块、流式且数值稳定地计算。若同时维护加权 Value 累加器，还能避免保存完整注意力矩阵，这是 FlashAttention 的数学核心之一。
+
+### 9.5 算例五：LoRA 的参数与计算
+
+完整线性层：
+
+$$
+\mathbf{y}=\mathbf{x}\mathbf{W}_0^\top
+$$
+
+LoRA：
+
+$$
+\mathbf{y}
+=\mathbf{x}\mathbf{W}_0^\top
++\frac{\alpha}{r}
+  (\mathbf{x}\mathbf{A}^\top)\mathbf{B}^\top
+$$
+
+形状：
+
+```text
+x:     (..., din)
+A^T:   (din, r)       -> (..., r)
+B^T:   (r, dout)      -> (..., dout)
+```
+
+在线 adapter 会多做两个小 GEMM；若提前把 $\mathbf{B}\mathbf{A}$ 合并进基座权重，推理仍是一个大 GEMM，但失去低成本动态切换 adapter 的便利。
+
+### 9.6 算例六：分布式均值为什么要加权
+
+两个 rank 的局部样本数分别为 $n_1,n_2$，局部均值为 $\mu_1,\mu_2$。全局均值不是简单的 $(\mu_1+\mu_2)/2$，除非 $n_1=n_2$。正确值：
+
+$$
+\mu=
+\frac{n_1\mu_1+n_2\mu_2}{n_1+n_2}
+$$
+
+更一般地，每个 rank 先汇总局部 `sum` 和 `count`，AllReduce 后再相除。分布式 loss、指标和吞吐统计都要明确分母，尤其是最后一个不完整 batch 或序列 mask 不同的场景。
+
+### 9.7 算例七：显存估算
+
+若一个张量 shape 为 $(B,S,H)$，元素字节数为 $b$，其连续存储大小：
+
+$$
+M=B\times S\times H\times b
+$$
+
+例如 BF16 的 $(8,4096,8192)$：
+
+$$
+8\times4096\times8192\times2
+=536{,}870{,}912\ \text{bytes}
+=512\ \text{MiB}
+$$
+
+训练峰值显存还包括参数、梯度、优化器状态、保存的激活、临时 workspace、通信 buffer、内存碎片和框架上下文。单个张量估算只是起点。
+
+### 9.8 从数学式到 Kernel 的固定检查表
+
+看到一个新算子时，按以下顺序拆解：
+
+1. 输入、输出和中间量的 shape 是什么？
+2. 哪些维度保留，哪些维度归约？
+3. 能否分块？分块状态如何合并？
+4. FLOPs 和理论最小访存量是多少？
+5. 是否存在广播、转置或非连续 stride？
+6. 哪些操作对精度敏感，需要高精度累加？
+7. 是否会出现 exp 溢出、除零、消减或长归约误差？
+8. 中间张量能否融合消除？
+9. 边界 shape 和尾块如何处理？
+10. 用什么参考实现、dtype 容差和极端输入验证？
+
+这份检查表把抽象数学转换成可执行的 Infra 工作流。
+
+---
+
+## 总结
+
+本章建立了四条相互连接的主线：
+
+- **线性代数**描述张量如何变换：shape 决定合法性，秩和分解决定压缩可能，分块决定数据如何复用；
+- **概率论**描述模型输出的含义：logits 经 Softmax 变成分布，交叉熵对应负对数似然，KL 衡量分布差异；
+- **微积分**描述参数如何学习：链式法则沿计算图反向传播，线性层反向仍由 GEMM 和归约构成；
+- **数值计算**决定公式在硬件上是否可靠：有限精度会舍入、溢出和下溢，稳定公式与混合精度策略同样重要。
+
+对 AI Infra 工程师而言，“懂数学”最终体现在：能把公式翻译成 shape、归约、分块、数据移动、精度选择和验证标准。
+
+## 自我检验清单
+
+- [ ] 看到 `(B, S, H) @ (H, V)` 能立即写出输出 shape
+- [ ] 能区分逐元素乘、点积、矩阵乘和 batched matmul
+- [ ] 能根据 shape/stride 判断转置视图是否连续
+- [ ] 能解释范数、秩、特征值和奇异值的直觉
+- [ ] 能计算低秩分解和 LoRA 的参数量节省比例
+- [ ] 能从 block 矩阵乘法解释 GEMM tiling 的正确性
+- [ ] 能估算 GEMM 的 FLOPs、最小访存量和算术强度
+- [ ] 能计算期望、方差、协方差和条件概率
+- [ ] 能写出稳定 Softmax 与 LogSumExp
+- [ ] 能说明交叉熵、熵和 KL 散度之间的关系
+- [ ] 能用链式法则推导简单计算图的梯度
+- [ ] 能写出线性层对输入、权重和 bias 的梯度 shape
+- [ ] 知道 Softmax + 交叉熵对 logits 的梯度是 `p - y`
+- [ ] 能解释残差连接为何改善梯度通路
+- [ ] 能区分精度、动态范围、溢出和下溢
+- [ ] 能说明 FP16 为什么常需要 Loss Scaling，而 BF16 通常不需要
+- [ ] 能解释并行归约为何可能产生非逐位一致结果
+- [ ] 能从 Attention shape 推导 $O(S^2)$ 中间量与显存成本
+
+## 练习题
+
+1. 推导 `(B, Nh, Sq, Dh) @ (B, Nh, Dh, Sk)` 的输出 shape，并标出 batch 维与归约维。
+2. 给定 $M=4096,K=4096,N=16384$ 的 FP16 GEMM，估算 FLOPs 和理想最小输入输出字节数。
+3. 写程序验证 $\operatorname{softmax}(\mathbf{z}+c)=\operatorname{softmax}(\mathbf{z})$，并比较朴素实现与稳定实现处理大 logits 的结果。
+4. 从 Softmax Jacobian 和交叉熵开始，手推 $\partial L/\partial z_i=p_i-y_i$。
+5. 推导 `Y = GELU(XW + b)` 的反向 shape，不要求展开 GELU 的具体导数。
+6. 比较 FP16、BF16 和 FP32 对序列 `[1, 1e-3, 1e-3, ...]` 求和的误差，并尝试改变求和顺序。
+7. 实现 Welford 方差，与 `E[x²] - E[x]²` 在“大均值、小方差”数据上的结果比较。
+8. 对一个 $4096\times4096$ 权重计算 rank 8、16、64 LoRA 的参数比例和额外前向 FLOPs。
+9. 计算 $B=2,N_h=32,S=8192,D_h=128$ 时显式 FP16 Attention score 矩阵的大小。
+10. 两个 rank 分别处理 7 个和 5 个有效 token，局部 loss 均值分别为 2.0 和 3.0；计算正确全局均值，并说明简单平均为什么错。
+11. 用有限差分检查一个小线性层手写反向，尝试不同 $\epsilon$ 并观察误差曲线。
+12. 选择一个 PyTorch 算子，按“shape、归约、FLOPs、访存、数值风险、验证方法”写一页分析。
+
+## 参考资料
+
+- [Deep Learning Book：Linear Algebra](https://www.deeplearningbook.org/contents/linear_algebra.html)
+- [Deep Learning Book：Probability and Information Theory](https://www.deeplearningbook.org/contents/prob.html)
+- [Deep Learning Book：Numerical Computation](https://www.deeplearningbook.org/contents/numerical.html)
+- [Matrix Calculus for Deep Learning](https://arxiv.org/abs/1802.01528)
+- [Automatic Differentiation in Machine Learning: a Survey](https://jmlr.org/papers/v18/17-468.html)
+- [LoRA: Low-Rank Adaptation of Large Language Models](https://arxiv.org/abs/2106.09685)
+- [Attention Is All You Need](https://arxiv.org/abs/1706.03762)
+- [FlashAttention: Fast and Memory-Efficient Exact Attention with IO-Awareness](https://arxiv.org/abs/2205.14135)
+- [NVIDIA Mixed Precision Training](https://docs.nvidia.com/deeplearning/performance/mixed-precision-training/)
+- [NVIDIA TensorFloat-32](https://blogs.nvidia.com/blog/tensorfloat-32-precision-format/)
+- [PyTorch Numerical Accuracy](https://docs.pytorch.org/docs/stable/notes/numerical_accuracy.html)
+- [PyTorch Broadcasting Semantics](https://docs.pytorch.org/docs/stable/notes/broadcasting.html)


### PR DESCRIPTION
## 概要

- 将第 1 章从占位提纲扩展为完整的编程语言基础教程，覆盖 Python 工程能力与性能分析、现代 C++ 内存/生命周期/编译链接、Python-C++ 互操作、Linux 与 GPU 开发环境。
- 将第 2 章扩展为面向 AI Infra 的数学基础教程，覆盖线性代数与 GEMM 分块、概率与 Softmax/交叉熵/KL、反向传播、数值稳定性和混合精度。
- 两章均补充目录、工程算例、自我检验清单、练习题与参考资料。

## 设计原则

- 保持项目“先白话后术语”的写作风格。
- 所有公式均连接到 shape、FLOPs、访存、分块或数值精度等实际 Infra 问题。
- 改动仅限两个目标章节，不包含无关重构或生成文件。

## 验证

- [x] `npm run build`
- [x] Astro check：0 errors
- [x] 成功生成 320 个静态页面及 Pagefind 索引
- [x] 检查 Markdown 代码围栏、KaTeX 数学块和章节目录锚点
- [x] 验证参考资料链接可访问

作者署名：lxyyxl