### PR TITLE
fix: correct KaTeX quad and qquad spacing commands

### DIFF
--- a/docs/guides/模块一-前置知识/第2章-数学基础.md
+++ b/docs/guides/模块一-前置知识/第2章-数学基础.md
@@ -1076,8 +1076,8 @@ $$
 多层网络就是复合函数。对：
 
 $$
-\mathbf{h}_1=f_1(\mathbf{x}),quad
-\mathbf{h}_2=f_2(\mathbf{h}_1),quad
+\mathbf{h}_1=f_1(\mathbf{x}),\quad
+\mathbf{h}_2=f_2(\mathbf{h}_1),\quad
 L=f_3(\mathbf{h}_2)
 $$
 
@@ -1144,8 +1144,8 @@ $$
 其中：
 
 $$
-\mathbf{X}\in\mathbb{R}^{B\times d_{in}},quad
-\mathbf{W}\in\mathbb{R}^{d_{in}\times d_{out}},quad
+\mathbf{X}\in\mathbb{R}^{B\times d_{in}},\quad
+\mathbf{W}\in\mathbb{R}^{d_{in}\times d_{out}},\quad
 \mathbf{Y}\in\mathbb{R}^{B\times d_{out}}
 $$
 

--- a/docs/guides/模块一-前置知识/第2章-数学基础.md
+++ b/docs/guides/模块一-前置知识/第2章-数学基础.md
@@ -229,7 +229,7 @@ $$
 比较浮点结果时，绝对误差和相对误差各有作用：
 
 $$
-e_{abs} = |\hat{x}-x|,qquad
+e_{abs} = |\hat{x}-x|,\qquad
 e_{rel} = \frac{|\hat{x}-x|}{|x|}
 $$
 
@@ -371,7 +371,7 @@ $$
 
 $$
 \mathbf{A} \approx
-\mathbf{U}\mathbf{V},qquad
+\mathbf{U}\mathbf{V},\qquad
 \mathbf{U}\in\mathbb{R}^{M\times r},
 \mathbf{V}\in\mathbb{R}^{r\times N},
 \quad r \ll \min(M,N)
@@ -441,7 +441,7 @@ $$
 其中：
 
 $$
-\mathbf{A}\in\mathbb{R}^{r\times d_{in}},qquad
+\mathbf{A}\in\mathbb{R}^{r\times d_{in}},\qquad
 \mathbf{B}\in\mathbb{R}^{d_{out}\times r}
 $$
 
@@ -473,7 +473,7 @@ $$
 \begin{bmatrix}
 \mathbf{A}_{11} & \mathbf{A}_{12}\\
 \mathbf{A}_{21} & \mathbf{A}_{22}
-\end{bmatrix},qquad
+\end{bmatrix},\qquad
 \mathbf{B}=
 \begin{bmatrix}
 \mathbf{B}_{11} & \mathbf{B}_{12}\\
@@ -583,13 +583,13 @@ $$
 随机变量把随机结果映射为数。离散随机变量用概率质量函数：
 
 $$
-p_X(x)=P(X=x),qquad \sum_x p_X(x)=1
+p_X(x)=P(X=x),\qquad \sum_x p_X(x)=1
 $$
 
 连续随机变量用概率密度函数：
 
 $$
-p_X(x)\ge0,qquad
+p_X(x)\ge0,\qquad
 \int_{-\infty}^{\infty}p_X(x)\,dx=1
 $$
 
@@ -1097,7 +1097,7 @@ $$
 设：
 
 $$
-a=xy,qquad b=a+x,qquad L=b^2
+a=xy,\qquad b=a+x,\qquad L=b^2
 $$
 
 前向阶段保存必要中间量。反向从：
@@ -1739,7 +1739,7 @@ $$
 一行 logits 被切成多个 block。已处理部分的最大值和指数和为 $(m,l)$：
 
 $$
-m=\max_i x_i,qquad
+m=\max_i x_i,\qquad
 l=\sum_i e^{x_i-m}
 $$
 


### PR DESCRIPTION
## Summary

Fixes malformed LaTeX spacing commands in Markdown math formulas where `quad` / `qquad` were missing the leading backslash and were rendered as plain letters by KaTeX.

## Changes

- Replaced `,qquad` with `,\qquad`
- Replaced `,quad` with `,\quad`
