### PR TITLE
docs: add CUDA operator practice resource

### DIFF
--- a/docs/guides/AI Infra学习路线.md
+++ b/docs/guides/AI Infra学习路线.md
@@ -162,6 +162,7 @@ AI Infra 不是从零开始学的领域——它建立在编程能力、数学�
 | 官方文档 | NVIDIA GPU 架构白皮书（Ampere / Hopper） | 理解 SM、Tensor Core、HBM 设计 |
 | 入门教程 | 小小将：CUDA编程入门极简教程 | CUDA 零基础入门 |
 | 官方文档 | NVIDIA CUDA Programming Guide | CUDA 编程权威参考 |
+| 练习平台 | [CUDA 手撕算子 · 面试练习](https://kkcocoa.github.io/cuda-operator-interview/) | 覆盖访存、Reduce、Softmax、Attention、GEMM 等算子的分级手写练习，附提示、自检清单与浏览器内代码编辑器 |
 | Reduce | PeakCrosser：CUDA Reduce 算子优化 | Reduce 实现与优化的详尽总结 |
 | GEMM | 猛猿：从啥也不会到CUDA GEMM优化 | 从基础分块到极致优化的 GEMM 教程 |
 | GEMM | MegEngine Bot：CUDA 矩阵乘法终极优化指南 | 系统性的 GEMM 优化参考 |


### PR DESCRIPTION
## What changed

- Added the CUDA operator interview-practice site to the CUDA programming and operator-optimization resource list.

## Why

This interactive practice resource complements the existing CUDA tutorials with hands-on drills for memory access, Reduce, Softmax, Attention, and GEMM.

## Validation

- Ran `astro check` and `astro build` successfully (0 errors).
- Confirmed the resource link and Markdown table formatting.